### PR TITLE
Sửa hiển thị icon npc trong EDITMAPv6

### DIFF
--- a/EDITMAPv6.html
+++ b/EDITMAPv6.html
@@ -2114,33 +2114,57 @@ class MapViewerApp {
 			getIconFrameRect(img) {
 			const w = img?.width || TILE_SIZE;
 			const h = img?.height || TILE_SIZE;
+			const clamp = (v, min, max) => Math.max(min, Math.min(max, v));
+			const nearInt = (x, eps) => Math.abs(x - Math.round(x)) <= eps;
 			let orientation = 'none';
-			if (h >= w + 2) orientation = 'vertical';
-			else if (w >= h + 2) orientation = 'horizontal';
-			const chooseFrames = (total, ortho) => {
-				const candidates = [2,3,4,5,6,8];
-				const tol = Math.max(1, Math.round(total * 0.02));
-				for (const f of candidates) { if (total % f <= tol) return f; }
-				let best = 1; let bestCost = Number.POSITIVE_INFINITY;
-				for (const f of candidates) { const seg = total / f; if (seg < 8) continue; const cost = Math.abs(seg - ortho); if (cost < bestCost) { bestCost = cost; best = f; } }
-				return best;
-			};
 			let frames = 1;
-			if (orientation === 'vertical') frames = chooseFrames(h, w);
-			else if (orientation === 'horizontal') frames = chooseFrames(w, h);
-			let sx = 0, sy = 0, sw = w, sh = h;
-			const idx = frames > 1 ? Math.floor(Date.now() / this.animationTickMs) % frames : 0;
-			if (orientation === 'vertical' && frames > 1) {
-				const start = Math.round(idx * h / frames);
-				const end = Math.round((idx + 1) * h / frames);
-				sy = start; sh = Math.max(1, end - start);
-			} else if (orientation === 'horizontal' && frames > 1) {
-				const start = Math.round(idx * w / frames);
-				const end = Math.round((idx + 1) * w / frames);
-				sx = start; sw = Math.max(1, end - start);
+			// Ưu tiên phát hiện sprite-sheet theo tỉ lệ gần số nguyên 2..8 và mỗi frame gần-vuông
+			const tryVertical = () => {
+				const ratio = h / w;
+				const n = Math.round(ratio);
+				if (n >= 2 && n <= 8 && nearInt(ratio, 0.08)) {
+					const seg = h / n;
+					if (Math.abs(seg / w - 1) <= 0.15) return n;
+				}
+				return 1;
+			};
+			const tryHorizontal = () => {
+				const ratio = w / h;
+				const n = Math.round(ratio);
+				if (n >= 2 && n <= 8 && nearInt(ratio, 0.08)) {
+					const seg = w / n;
+					if (Math.abs(seg / h - 1) <= 0.15) return n;
+				}
+				return 1;
+			};
+			const fv = tryVertical();
+			const fh = tryHorizontal();
+			if (fv > 1 || fh > 1) {
+				if (fv > 1 && fh > 1) {
+					// Chọn phương án cho frame gần vuông hơn
+					const errV = Math.abs((h / fv) / w - 1);
+					const errH = Math.abs((w / fh) / h - 1);
+					if (errV <= errH) { orientation = 'vertical'; frames = fv; } else { orientation = 'horizontal'; frames = fh; }
+				} else if (fv > 1) { orientation = 'vertical'; frames = fv; }
+				else { orientation = 'horizontal'; frames = fh; }
 			}
-			if (sx + sw > w) sw = w - sx;
-			if (sy + sh > h) sh = h - sy;
+			let sx = 0, sy = 0, sw = w, sh = h;
+			if (frames > 1) {
+				const idx = Math.floor(Date.now() / this.animationTickMs) % frames;
+				if (orientation === 'vertical') {
+					const seg = h / frames;
+					const start = Math.round(idx * seg);
+					const end = Math.round((idx + 1) * seg);
+					sy = clamp(start, 0, h - 1);
+					sh = clamp(end - start, 1, h - sy);
+				} else if (orientation === 'horizontal') {
+					const seg = w / frames;
+					const start = Math.round(idx * seg);
+					const end = Math.round((idx + 1) * seg);
+					sx = clamp(start, 0, w - 1);
+					sw = clamp(end - start, 1, w - sx);
+				}
+			}
 			return { sx, sy, sw, sh };
 		}
 

--- a/EDITMAPv6.html
+++ b/EDITMAPv6.html
@@ -2117,16 +2117,32 @@ class MapViewerApp {
 				const w = img?.width || TILE_SIZE;
 				const h = img?.height || TILE_SIZE;
 				const ratio = h / Math.max(1, w);
-				// Stable detection: prefer divisibility; special-case small-width sprites
+				// Detect midline seam (2-frame) for ambiguous tall sprites (e.g., 22x88, 25x88)
 				let frames = 1;
 				const r = ratio;
-				const isSmall = w <= 24;
-				const near = (x, y, tol) => Math.abs(x - y) <= tol;
-				if ((h % 4 === 0 || near(r, 4, 0.05)) && ((isSmall && r >= 3.8) || (!isSmall && r >= 3.1))) frames = 4;
-				else if ((h % 2 === 0 || near(r, 2, 0.05)) && r >= 1.45) frames = 2;
-				else if ((isSmall && r >= 3.8) || (!isSmall && r >= 3.35)) frames = 4;
-				else if (r >= 1.45) frames = 2;
-				else frames = 1;
+				let forceTwo = false;
+				if (r >= 3.0 && r <= 4.2) {
+					try {
+						const c = document.createElement('canvas'); c.width = w; c.height = h; const ctx = c.getContext('2d'); ctx.imageSmoothingEnabled = false; ctx.drawImage(img, 0, 0);
+						const data = ctx.getImageData(0, 0, w, h).data;
+						const stripeAvg = (cy) => { const band = Math.max(1, Math.round(h * 0.04)); let sum = 0, cnt = 0; const y0 = Math.max(0, cy - band), y1 = Math.min(h - 1, cy + band); for (let y = y0; y <= y1; y++) { let o = y * w * 4 + 3; let s = 0; for (let x = 0; x < w; x++) { s += data[o]; o += 4; } sum += s / (255 * w); cnt++; } return cnt > 0 ? sum / cnt : 1; };
+						const mid = Math.floor(h / 2), q1 = Math.floor(h / 4), q3 = Math.floor((3 * h) / 4);
+						const m = stripeAvg(mid), a = stripeAvg(q1), b = stripeAvg(q3);
+						if (m <= Math.min(a, b) - 0.06) forceTwo = true;
+					} catch {}
+				}
+				if (forceTwo) {
+					frames = 2;
+				} else {
+					// Prefer divisibility; special-case small-width sprites
+					const isSmall = w <= 24;
+					const near = (x, y, tol) => Math.abs(x - y) <= tol;
+					if ((h % 4 === 0 || near(r, 4, 0.05)) && ((isSmall && r >= 3.8) || (!isSmall && r >= 3.1))) frames = 4;
+					else if ((h % 2 === 0 || near(r, 2, 0.05)) && r >= 1.45) frames = 2;
+					else if ((isSmall && r >= 3.8) || (!isSmall && r >= 3.35)) frames = 4;
+					else if (r >= 1.45) frames = 2;
+					else frames = 1;
+				}
 				const slices = [];
 				if (frames === 1) { slices.push({ sy: 0, sh: h }); return slices; }
 				const per = Math.floor(h / frames);

--- a/EDITMAPv6.html
+++ b/EDITMAPv6.html
@@ -2124,7 +2124,7 @@ class MapViewerApp {
 				const alphaRow = new Float32Array(h);
 				for (let y = 0; y < h; y++) { let sum = 0; let o = y * w * 4 + 3; for (let x = 0; x < w; x++) { sum += data[o]; o += 4; } alphaRow[y] = sum / (255 * w); }
 				const clamp = (v, min, max) => Math.max(min, Math.min(max, v));
-				const window = Math.max(1, Math.round(h * 0.08));
+				const window = Math.max(1, Math.round(h * 0.12));
 				const targets = frames === 2 ? [h / 2] : [h / 4, h / 2, (3 * h) / 4];
 				const seams = [];
 				for (const t of targets) {
@@ -2132,7 +2132,10 @@ class MapViewerApp {
 					const s = clamp(Math.round(t) - window, 1, h - 2);
 					const e = clamp(Math.round(t) + window, 1, h - 2);
 					for (let y = s; y <= e; y++) {
-						const score = alphaRow[y];
+						// Ưu tiên đường cắt ở vùng trong suốt (alpha thấp) và ở giữa hai vùng đặc (biên gradient nhỏ)
+						const prev = Math.max(0, y - 1), next = Math.min(h - 1, y + 1);
+						const grad = Math.abs(alphaRow[next] - alphaRow[prev]);
+						const score = alphaRow[y] + grad * 0.25;
 						if (score < bestScore) { bestScore = score; bestY = y; }
 					}
 					seams.push(bestY);

--- a/EDITMAPv6.html
+++ b/EDITMAPv6.html
@@ -2149,14 +2149,11 @@ class MapViewerApp {
 					slices.push({ sy: 0, sh: Math.max(1, s) });
 					slices.push({ sy: s + 1, sh: Math.max(1, h - s - 1) });
 				} else {
-					const margin = Math.round(h * 0.08);
-					const mid = findSeamBetween(margin, h - margin);
-					const top = findSeamBetween(margin, mid - Math.max(1, Math.floor(margin / 2)));
-					const bot = findSeamBetween(mid + Math.max(1, Math.floor(margin / 2)), h - margin);
-					slices.push({ sy: 0, sh: Math.max(1, top) });
-					slices.push({ sy: top + 1, sh: Math.max(1, mid - (top + 1)) });
-					slices.push({ sy: mid + 1, sh: Math.max(1, bot - (mid + 1)) });
-					slices.push({ sy: bot + 1, sh: Math.max(1, h - (bot + 1)) });
+					// 4-frame: quay về cắt đều để đảm bảo ổn định như trước (không dò seam)
+					const per = Math.floor(h / 4);
+					const rem = h - per * 4;
+					let y0 = 0;
+					for (let i = 0; i < 4; i++) { const extra = i < rem ? 1 : 0; const sh = per + extra; slices.push({ sy: y0, sh }); y0 += sh; }
 				}
 				const minSh = Math.max(1, Math.floor(h / (frames * 4)));
 				if (slices.length !== frames || slices.some(s => s.sh < minSh)) { slices.length = 0; const per = Math.floor(h / frames); const rem = h - per * frames; let y0 = 0; for (let i = 0; i < frames; i++) { const extra = i < rem ? 1 : 0; const sh = per + extra; slices.push({ sy: y0, sh }); y0 += sh; } }

--- a/EDITMAPv6.html
+++ b/EDITMAPv6.html
@@ -2117,10 +2117,14 @@ class MapViewerApp {
 				const w = img?.width || TILE_SIZE;
 				const h = img?.height || TILE_SIZE;
 				const ratio = h / Math.max(1, w);
-				// Stable detection: simple ratio-based
+				// Stable detection: prefer divisibility; then ratio thresholds for vertical sprites
 				let frames = 1;
 				const r = ratio;
-				if (r >= 3.9) frames = 4; else if (r >= 2.0) frames = 2; else frames = 1;
+				if (h % 4 === 0 && r >= 3.1) frames = 4;
+				else if (h % 2 === 0 && r >= 1.45) frames = 2;
+				else if (r >= 3.4) frames = 4;
+				else if (r >= 1.5) frames = 2;
+				else frames = 1;
 				const slices = [];
 				if (frames === 1) { slices.push({ sy: 0, sh: h }); return slices; }
 				const per = Math.floor(h / frames);

--- a/EDITMAPv6.html
+++ b/EDITMAPv6.html
@@ -534,9 +534,10 @@ class MapViewerApp {
 	
 	mapData = null;
 	tilesetImage = null;
-	effectIcons = new Map();
-	originalMapFileName = '';
-	showOverlays = true;
+			effectIcons = new Map();
+		npcFrameCache = new WeakMap();
+		originalMapFileName = '';
+		showOverlays = true;
 	animationTickMs = 160;
 	animationTimer = null;
 
@@ -2112,23 +2113,30 @@ class MapViewerApp {
 	}
 
 			getIconFrameRect(img) {
-			// Dùng cho NPC: coi sprite-sheet dọc với 1/2/4 frame; ảnh tĩnh (1 frame) giữ nguyên.
+			// NPC only: cache per image to avoid inconsistent splits; support 1/2/4 vertical frames.
+			const cached = this.npcFrameCache.get(img);
 			const w = img?.width || TILE_SIZE;
 			const h = img?.height || TILE_SIZE;
 			let frames = 1;
-			if (w > 0 && h > 0) {
+			if (cached && cached.w === w && cached.h === h) {
+				frames = cached.frames;
+			} else {
 				const ratio = h / w;
-				// Ngưỡng mềm: >=3.1 ~ 4 khung, >=1.5 ~ 2 khung, còn lại 1 khung
 				if (ratio >= 3.1) frames = 4;
 				else if (ratio >= 1.5) frames = 2;
 				else frames = 1;
+				this.npcFrameCache.set(img, { w, h, frames });
 			}
 			let sx = 0, sy = 0, sw = w, sh = h;
 			if (frames > 1) {
 				const idx = Math.floor(Date.now() / this.animationTickMs) % frames;
-				const per = Math.round(h / frames);
-				sy = Math.min(h - 1, Math.max(0, idx * per));
-				sh = Math.max(1, Math.min(h - sy, per));
+				const per = Math.floor(h / frames);
+				const remainder = h - per * frames;
+				// distribute remainder pixels to top frames to avoid missing bottom row
+				const extraForThis = Math.min(1, Math.max(0, idx < remainder ? 1 : 0));
+				const offsetExtras = Math.min(remainder, idx);
+				sy = idx * per + offsetExtras;
+				sh = per + extraForThis;
 			}
 			return { sx, sy, sw, sh };
 		}

--- a/EDITMAPv6.html
+++ b/EDITMAPv6.html
@@ -2117,62 +2117,28 @@ class MapViewerApp {
 				const w = img?.width || TILE_SIZE;
 				const h = img?.height || TILE_SIZE;
 				const ratio = h / Math.max(1, w);
-				const near = (x, y, tol) => Math.abs(x - y) <= tol;
-				let frames = near(ratio, 4, 0.35) ? 4 : 1;
-				// không return sớm; sẽ thử dò seam giữa ảnh để xác nhận 2-frame, nếu không được thì giữ 1-frame
-				const c = document.createElement('canvas'); c.width = w; c.height = h; const ctx = c.getContext('2d'); ctx.imageSmoothingEnabled = false; ctx.drawImage(img, 0, 0);
-				const data = ctx.getImageData(0, 0, w, h).data;
-				const solidRow = new Float32Array(h);
-				const A = 24;
-				for (let y = 0; y < h; y++) { let cnt = 0; let o = y * w * 4 + 3; for (let x = 0; x < w; x++) { if (data[o] >= A) cnt++; o += 4; } solidRow[y] = cnt / w; }
-				const k = Math.max(1, Math.round(h * 0.02));
-				const smoothed = new Float32Array(h);
-				for (let y = 0; y < h; y++) { let sum = 0, num = 0; const s = Math.max(0, y - k), e = Math.min(h - 1, y + k); for (let t = s; t <= e; t++) { sum += solidRow[t]; num++; } smoothed[y] = sum / Math.max(1, num); }
-				const clamp = (v, min, max) => Math.max(min, Math.min(max, v));
-				const findSeamBetween = (lo, hi) => {
-					const L = clamp(Math.floor(lo), 1, h - 2);
-					const R = clamp(Math.floor(hi), 1, h - 2);
-					let yMin = Math.floor((L + R) / 2); let best = Number.POSITIVE_INFINITY;
-					for (let y = L; y <= R; y++) { const prev = Math.max(0, y - 1), next = Math.min(h - 1, y + 1); const grad = Math.abs(smoothed[next] - smoothed[prev]); const score = smoothed[y] + grad * 0.3; if (score < best) { best = score; yMin = y; } }
-					const solidThr = Math.max(0.03, Math.min(0.15, best * 0.8));
-					let top = yMin; while (top > L && smoothed[top] <= solidThr) top--;
-					let bot = yMin; while (bot < R && smoothed[bot] <= solidThr) bot++;
-					let lastTop = top; while (lastTop >= L && solidRow[lastTop] <= solidThr) lastTop--;
-					let firstBot = bot; while (firstBot <= R && solidRow[firstBot] <= solidThr) firstBot++;
-					let seam = Math.floor((Math.max(L, lastTop) + Math.min(R, firstBot)) / 2);
-					seam = clamp(seam, L, R - 1);
-					return seam;
-				};
-				const slices = [];
-				if (frames === 4) {
-					// 4-frame ổn định: chia đều theo chiều cao
-					const per = Math.floor(h / 4);
-					const rem = h - per * 4;
-					let y0 = 0;
-					for (let i = 0; i < 4; i++) { const extra = i < rem ? 1 : 0; const sh = per + extra; slices.push({ sy: y0, sh }); y0 += sh; }
-				} else {
-					// Thử phát hiện 2-frame bằng seam ở giữa; nếu seam yếu, coi như 1-frame
-					const margin = Math.round(h * 0.12);
-					const s = findSeamBetween(margin, h - margin);
-					const band = Math.max(1, Math.round(h * 0.05));
-					let centerSum = 0, centerN = 0; for (let y = Math.max(1, s - band); y <= Math.min(h - 2, s + band); y++) { centerSum += smoothed[y]; centerN++; }
-					const centerAvg = centerN > 0 ? centerSum / centerN : 1;
-					let leftSum = 0, leftN = 0; const leftEnd = Math.max(1, s - band); const leftStart = Math.max(1, leftEnd - Math.round(h * 0.12)); for (let y = leftStart; y < leftEnd; y++) { leftSum += smoothed[y]; leftN++; }
-					let rightSum = 0, rightN = 0; const rightStart = Math.min(h - 2, s + band + 1); const rightEnd = Math.min(h - 2, rightStart + Math.round(h * 0.12)); for (let y = rightStart; y <= rightEnd; y++) { rightSum += smoothed[y]; rightN++; }
-					const leftAvg = leftN > 0 ? leftSum / leftN : 1;
-					const rightAvg = rightN > 0 ? rightSum / rightN : 1;
-					const sideAvg = Math.min(leftAvg, rightAvg);
-					const balance = Math.abs((s / h) - 0.5);
-					const accept = (centerAvg <= 0.18 && (sideAvg - centerAvg) >= 0.06) || (centerAvg <= sideAvg * 0.7) || (balance <= 0.08 && centerAvg <= 0.35);
-					if (accept) {
-						slices.push({ sy: 0, sh: Math.max(1, s) });
-						slices.push({ sy: s + 1, sh: Math.max(1, h - s - 1) });
-					} else {
-						slices.push({ sy: 0, sh: h });
+				// Stable detection: prefer exact divisibility, fall back to ratio thresholds
+				let frames = 1;
+				if (h >= w * 1.2) {
+					if (h % 4 === 0 && ratio >= 3.0) frames = 4;
+					else if (h % 2 === 0 && ratio >= 2.1) frames = 2;
+					else {
+						const near = (x, y, tol) => Math.abs(x - y) <= tol;
+						if (near(ratio, 4, 0.25)) frames = 4;
+						else if (near(ratio, 2, 0.25)) frames = 2;
 					}
 				}
-				const minSh = Math.max(1, Math.floor(h / (frames * 4)));
-				if (slices.length !== frames || slices.some(s => s.sh < minSh)) { slices.length = 0; const per = Math.floor(h / frames); const rem = h - per * frames; let y0 = 0; for (let i = 0; i < frames; i++) { const extra = i < rem ? 1 : 0; const sh = per + extra; slices.push({ sy: y0, sh }); y0 += sh; } }
+				const slices = [];
+				if (frames === 1) { slices.push({ sy: 0, sh: h }); return slices; }
+				const per = Math.floor(h / frames);
+				const rem = h - per * frames;
+				let y0 = 0;
+				for (let i = 0; i < frames; i++) {
+					const extra = i < rem ? 1 : 0;
+					const sh = per + extra;
+					slices.push({ sy: y0, sh: Math.max(1, sh) });
+					y0 += sh;
+				}
 				return slices;
 			} catch { return [{ sy: 0, sh: img?.height || TILE_SIZE }]; }
 		}

--- a/EDITMAPv6.html
+++ b/EDITMAPv6.html
@@ -782,10 +782,8 @@ class MapViewerApp {
 				document.getElementById('fp-tileset-lib')?.addEventListener('change', this.handleTilesetLibrary.bind(this));
 				document.getElementById('fp-apply-tileset-id')?.addEventListener('click', () => {
 					const idEl = document.getElementById('fp-tileset-id-override');
-					const updEl = document.getElementById('fp-tileset-update-mapid');
 					const id = Math.max(0, parseInt(idEl?.value || '0', 10) || 0);
-					const update = !!(updEl && updEl.checked);
-					this.applyTilesetById(id, update);
+					this.applyTilesetById(id);
 				});
 				document.getElementById('fp-icon-input')?.addEventListener('change', this.handleIconFiles.bind(this));
 				document.getElementById('fp-save-map-button')?.addEventListener('click', this.handleSaveMap.bind(this));
@@ -1054,7 +1052,7 @@ class MapViewerApp {
 			this.log(`Thông tin map:\n- Tên: ${this.mapData.mapName}\n- Kích thước: ${this.mapData.width}x${this.mapData.height}\n- Tileset ID: ${this.mapData.tilesetId}\n- Version: 0x${this.mapData.mapVersion.toString(16).toUpperCase()}`);
 			// Nếu đã có thư viện tileset, tự áp dụng theo ID map
 			if (this.tilesetLibrary && this.tilesetLibrary.main && this.tilesetLibrary.main.size > 0) {
-				this.applyTilesetById(this.mapData.tilesetId, false);
+				this.applyTilesetById(this.mapData.tilesetId);
 			}
 			this.mapData.tileMap = [];
 			const tileData = reader.readBytes(this.mapData.width * this.mapData.height);
@@ -2235,18 +2233,18 @@ class MapViewerApp {
 		}
 	}
 
-	applyTilesetById(id, updateMapId = false) {
-		const img = this.tilesetLibrary?.main?.get(id);
-		if (!img) { this.log(`Không tìm thấy tile${id}.png trong thư viện.`); return; }
-		this.tilesetImage = img;
-		if (this.mapData && updateMapId) {
-			this.mapData.tilesetId = id | 0;
-			this.calculateCollisionMap();
+			applyTilesetById(id) {
+			const img = this.tilesetLibrary?.main?.get(id);
+			if (!img) { this.log(`Không tìm thấy tile${id}.png trong thư viện.`); return; }
+			this.tilesetImage = img;
+			if (this.mapData) {
+				this.mapData.tilesetId = id | 0;
+				this.calculateCollisionMap();
+			}
+			this.populateTilePalette();
+			this.render();
+			this.log(`Đã áp dụng tileset ID ${id} từ thư viện và cập nhật tilesetId của map.`);
 		}
-		this.populateTilePalette();
-		this.render();
-		this.log(`Đã áp dụng tileset từ thư viện: tile${id}.png${updateMapId ? ' (đã cập nhật tilesetId của map)' : ''}.`);
-	}
 }
 
 new MapViewerApp();

--- a/EDITMAPv6.html
+++ b/EDITMAPv6.html
@@ -534,6 +534,8 @@ class MapViewerApp {
 	
 	mapData = null;
 	tilesetImage = null;
+	tilesetWaterImage = null;
+	tilesetSmallImage = null;
 	tilesetLibrary = { main: new Map(), water: new Map(), small: new Map() };
 	effectIcons = new Map();
 	npcFrameCache = new WeakMap();
@@ -756,6 +758,16 @@ class MapViewerApp {
 						<label for="fp-tileset-input">Ảnh Tileset (.png)</label>
 						<input type="file" id="fp-tileset-input" accept=".png">
 					</div>
+					<div class="grid-2" style="gap:8px;">
+						<div>
+							<label for="fp-tileset-water-input">Ảnh Tile Water (.png, tuỳ chọn)</label>
+							<input type="file" id="fp-tileset-water-input" accept=".png">
+						</div>
+						<div>
+							<label for="fp-tileset-small-input">Ảnh Tile Small (.png, tuỳ chọn)</label>
+							<input type="file" id="fp-tileset-small-input" accept=".png">
+						</div>
+					</div>
 					<div class="grid-2" style="gap:8px; align-items:end;">
 						<div>
 							<label for="fp-tileset-id-only">Thiết lập tilesetId (byte thứ 3 của tileBlob)</label>
@@ -776,10 +788,13 @@ class MapViewerApp {
 					</div>
 					<div class="inline" style="gap: 8px;">
 						<button id="fp-save-map-button" class="action-button" ${this.mapData ? '' : 'disabled'}>Lưu Dữ Liệu (CMD 12)</button>
+						<button id="fp-export-tileset-extras" class="action-button" style="background-color:#5b9bd5;">Xuất water/small theo ID</button>
 					</div>
 				`;
 				document.getElementById('fp-map-input')?.addEventListener('change', this.handleMapFile.bind(this));
 				document.getElementById('fp-tileset-input')?.addEventListener('change', this.handleTilesetFile.bind(this));
+				document.getElementById('fp-tileset-water-input')?.addEventListener('change', this.handleTilesetWaterFile.bind(this));
+				document.getElementById('fp-tileset-small-input')?.addEventListener('change', this.handleTilesetSmallFile.bind(this));
 				document.getElementById('fp-apply-tileset-id-only')?.addEventListener('click', () => {
 					const idEl = document.getElementById('fp-tileset-id-only');
 					const id = Math.max(0, parseInt(idEl?.value || '0', 10) || 0);
@@ -791,6 +806,7 @@ class MapViewerApp {
 					this.headerByte2 = v;
 					this.log(`Đã cập nhật header byte #2 = ${v}. Sẽ lưu vào hai byte đầu file.`);
 				});
+				document.getElementById('fp-export-tileset-extras')?.addEventListener('click', this.exportTilesetExtras.bind(this));
 				document.getElementById('fp-icon-input')?.addEventListener('change', this.handleIconFiles.bind(this));
 				document.getElementById('fp-save-map-button')?.addEventListener('click', this.handleSaveMap.bind(this));
 				break;
@@ -2223,6 +2239,38 @@ class MapViewerApp {
 	startAnimationLoop() {
 		if (this.animationTimer) clearInterval(this.animationTimer);
 		this.animationTimer = setInterval(() => { if (this.mapData) this.render(); }, this.animationTickMs);
+	}
+
+	async handleTilesetWaterFile(event) {
+		const input = event.target;
+		if (!input.files || input.files.length === 0) return;
+		const file = input.files[0];
+		const img = new Image();
+		img.onload = () => { this.tilesetWaterImage = img; this.log(`Đã nạp tilewater: ${file.name}`); };
+		img.onerror = () => { this.log(`LỖI: Không thể nạp tilewater '${file.name}'.`); this.tilesetWaterImage = null; };
+		img.src = URL.createObjectURL(file);
+	}
+
+	async handleTilesetSmallFile(event) {
+		const input = event.target;
+		if (!input.files || input.files.length === 0) return;
+		const file = input.files[0];
+		const img = new Image();
+		img.onload = () => { this.tilesetSmallImage = img; this.log(`Đã nạp tile_small: ${file.name}`); };
+		img.onerror = () => { this.log(`LỖI: Không thể nạp tile_small '${file.name}'.`); this.tilesetSmallImage = null; };
+		img.src = URL.createObjectURL(file);
+	}
+
+	exportTilesetExtras() {
+		if (!this.mapData) { this.log('Chưa có map để xuất water/small.'); return; }
+		const id = this.mapData.tilesetId | 0;
+		const downloadImg = (img, fname) => {
+			try { const c = document.createElement('canvas'); c.width = img.width; c.height = img.height; const x = c.getContext('2d'); x.imageSmoothingEnabled = false; x.drawImage(img, 0, 0); c.toBlob((blob) => { if (!blob) return; const a = document.createElement('a'); a.href = URL.createObjectURL(blob); a.download = fname; document.body.appendChild(a); a.click(); document.body.removeChild(a); setTimeout(()=>URL.revokeObjectURL(a.href), 500); }); } catch {}
+		};
+		let any = false;
+		if (this.tilesetWaterImage) { any = true; downloadImg(this.tilesetWaterImage, `tilewater${id}.png`); downloadImg(this.tilesetWaterImage, `102_${id}.png`); }
+		if (this.tilesetSmallImage) { any = true; downloadImg(this.tilesetSmallImage, `tile_small${id}.png`); downloadImg(this.tilesetSmallImage, `101_${id}.png`); }
+		if (!any) this.log('Chưa nạp ảnh water/small để xuất.'); else this.log('Đã xuất water/small theo ID hiện tại.');
 	}
 }
 

--- a/EDITMAPv6.html
+++ b/EDITMAPv6.html
@@ -756,21 +756,13 @@ class MapViewerApp {
 						<label for="fp-tileset-input">Ảnh Tileset (.png)</label>
 						<input type="file" id="fp-tileset-input" accept=".png">
 					</div>
-					<div class="file-input-group">
-						<label for="fp-tileset-lib">Thư viện Tileset (chọn thư mục chứa tile{id}.png, tilewater{id}.png, tile_small{id}.png)</label>
-						<input type="file" id="fp-tileset-lib" accept=".png" multiple webkitdirectory directory>
-					</div>
 					<div class="grid-2" style="gap:8px; align-items:end;">
 						<div>
-							<label for="fp-tileset-id-override">Áp dụng tileset theo ID</label>
-							<input type="number" id="fp-tileset-id-override" min="0" step="1" placeholder="VD: 9" />
-							<div class="inline" style="margin-top:6px; gap:6px;">
-								<input type="checkbox" id="fp-tileset-update-mapid" />
-								<label for="fp-tileset-update-mapid">Cập nhật tilesetId của map</label>
-							</div>
+							<label for="fp-tileset-id-only">Thiết lập tilesetId (byte thứ 3 của map)</label>
+							<input type="number" id="fp-tileset-id-only" min="0" step="1" placeholder="VD: 1" />
 						</div>
 						<div class="inline" style="gap:6px;">
-							<button id="fp-apply-tileset-id" class="action-button">Áp dụng</button>
+							<button id="fp-apply-tileset-id-only" class="action-button">Cập nhật ID map</button>
 						</div>
 					</div>
 					<div class="inline" style="gap: 8px;">
@@ -779,11 +771,10 @@ class MapViewerApp {
 				`;
 				document.getElementById('fp-map-input')?.addEventListener('change', this.handleMapFile.bind(this));
 				document.getElementById('fp-tileset-input')?.addEventListener('change', this.handleTilesetFile.bind(this));
-				document.getElementById('fp-tileset-lib')?.addEventListener('change', this.handleTilesetLibrary.bind(this));
-				document.getElementById('fp-apply-tileset-id')?.addEventListener('click', () => {
-					const idEl = document.getElementById('fp-tileset-id-override');
+				document.getElementById('fp-apply-tileset-id-only')?.addEventListener('click', () => {
+					const idEl = document.getElementById('fp-tileset-id-only');
 					const id = Math.max(0, parseInt(idEl?.value || '0', 10) || 0);
-					this.applyTilesetById(id);
+					this.applyTilesetIdOnly(id);
 				});
 				document.getElementById('fp-icon-input')?.addEventListener('change', this.handleIconFiles.bind(this));
 				document.getElementById('fp-save-map-button')?.addEventListener('click', this.handleSaveMap.bind(this));
@@ -2214,50 +2205,6 @@ class MapViewerApp {
 		if (this.animationTimer) clearInterval(this.animationTimer);
 		this.animationTimer = setInterval(() => { if (this.mapData) this.render(); }, this.animationTickMs);
 	}
-
-	async handleTilesetLibrary(event) {
-		const input = event.target;
-		if (!input.files) return;
-		const files = Array.from(input.files);
-		if (files.length === 0) { this.log('Không có file tileset nào được chọn.'); return; }
-		let loaded = 0, skipped = 0;
-		const loadImg = (file) => new Promise((resolve, reject) => { const img = new Image(); img.onload = () => resolve(img); img.onerror = reject; img.src = URL.createObjectURL(file); });
-		for (const f of files) {
-			const name = (f.webkitRelativePath || f.name || '').replace(/\\/g,'/');
-			const base = name.substring(name.lastIndexOf('/')+1).toLowerCase();
-			const match = base.match(/^(tilewater|tile_small|tilesmall|tile)(\d+)\.png$/i);
-			if (!match) { skipped++; continue; }
-			const kindRaw = match[1];
-			const id = parseInt(match[2], 10);
-			if (!Number.isFinite(id)) { skipped++; continue; }
-			let kind = 'main';
-			if (kindRaw === 'tilewater') kind = 'water';
-			else if (kindRaw === 'tile_small' || kindRaw === 'tilesmall') kind = 'small';
-			try {
-				const img = await loadImg(f);
-				this.tilesetLibrary[kind].set(id, img);
-				loaded++;
-			} catch { skipped++; }
-		}
-		this.log(`Thư viện tileset: đã tải ${loaded} ảnh, bỏ qua ${skipped}.`);
-		// Auto-apply nếu map đang mở
-		if (this.mapData && this.tilesetLibrary.main.has(this.mapData.tilesetId)) {
-			this.applyTilesetById(this.mapData.tilesetId, false);
-		}
-	}
-
-			applyTilesetById(id) {
-			const img = this.tilesetLibrary?.main?.get(id);
-			if (!img) { this.log(`Không tìm thấy tile${id}.png trong thư viện.`); return; }
-			this.tilesetImage = img;
-			if (this.mapData) {
-				this.mapData.tilesetId = id | 0;
-				this.calculateCollisionMap();
-			}
-			this.populateTilePalette();
-			this.render();
-			this.log(`Đã áp dụng tileset ID ${id} từ thư viện và cập nhật tilesetId của map.`);
-		}
 }
 
 new MapViewerApp();

--- a/EDITMAPv6.html
+++ b/EDITMAPv6.html
@@ -777,6 +777,7 @@ class MapViewerApp {
 							<button id="fp-apply-tileset-id-only" class="action-button">Cập nhật ID map</button>
 						</div>
 					</div>
+					<div id="fp-tileset-info" class="small-muted" style="margin:6px 0; line-height:1.4;"></div>
 					<div class="grid-2" style="gap:8px; align-items:end;">
 						<div>
 							<label for="fp-header-b2">Header byte #2 (cột thứ 2 đầu file)</label>
@@ -809,6 +810,7 @@ class MapViewerApp {
 				document.getElementById('fp-export-tileset-extras')?.addEventListener('click', this.exportTilesetExtras.bind(this));
 				document.getElementById('fp-icon-input')?.addEventListener('change', this.handleIconFiles.bind(this));
 				document.getElementById('fp-save-map-button')?.addEventListener('click', this.handleSaveMap.bind(this));
+				this.updateTilesetInfoDisplay();
 				break;
 			case 'resize':
 				if (title) title.textContent = 'Chỉnh Kích Thước';
@@ -1228,6 +1230,8 @@ class MapViewerApp {
 			// Nếu người dùng đã nhập ID-only, cập nhật ngay mapId
 			const idOnly = document.getElementById('fp-tileset-id-only');
 			if (idOnly && this.mapData) { const id = Math.max(0, parseInt(idOnly.value || '', 10) || this.mapData.tilesetId); this.applyTilesetIdOnly(id); }
+			this.lastTilesetFileName = file.name || '';
+			this.updateTilesetInfoDisplay();
 		};
 		this.tilesetImage.onerror = () => { this.log(`LỖI: Không thể tải ảnh tileset '${file.name}'.`); this.tilesetImage = null; }
 		this.tilesetImage.src = URL.createObjectURL(file);
@@ -1236,11 +1240,40 @@ class MapViewerApp {
 	applyTilesetIdOnly(id) {
 		if (!this.mapData) { this.log('Chưa có map để cập nhật tilesetId.'); return; }
 		const newId = id | 0;
-		if (this.mapData.tilesetId === newId) { this.log(`tilesetId đã là ${newId}.`); return; }
+		if (this.mapData.tilesetId === newId) { this.log(`tilesetId đã là ${newId}.`); this.updateTilesetInfoDisplay(); return; }
 		this.mapData.tilesetId = newId;
 		this.calculateCollisionMap();
 		this.render();
 		this.log(`Đã cập nhật tilesetId của map thành ${newId}. Khi lưu, byte thứ 3 sẽ là ${newId}.`);
+		this.updateTilesetInfoDisplay();
+	}
+
+	updateTilesetInfoDisplay() {
+		try {
+			const wrap = document.getElementById('fp-tileset-info');
+			if (!wrap) return;
+			const id = this.mapData ? (this.mapData.tilesetId | 0) : null;
+			const fname = this.lastTilesetFileName || '';
+			let detected = null;
+			if (fname) {
+				const low = fname.toLowerCase();
+				let m = low.match(/(?:^|[^0-9])(\d+)(?=\.png$)/i); // last number before .png
+				if (!m) m = low.match(/(?:tile|100_|101_|102_)(\d+)/);
+				if (m) detected = parseInt(m[1], 10);
+			}
+			let html = '';
+			if (id !== null) {
+				html += `Tileset ID (map): <b>${id}</b>. Yêu cầu ảnh: <code>tile${id}.png</code> hoặc <code>100_${id}.png</code>.`;
+				html += ` Water (tuỳ chọn): <code>tilewater${id}.png</code>/<code>102_${id}.png</code>. Small: <code>tile_small${id}.png</code>/<code>101_${id}.png</code>.`;
+			}
+			if (detected !== null && id !== null) {
+				if (detected !== id) html += ` <span style="color:#f87171; font-weight:600;">Cảnh báo: file '${fname}' có id ${detected} KHÁC id map ${id}.</span>`;
+				else html += ` <span style="color:#34d399;">Ảnh '${fname}' khớp id map.</span>`;
+			} else if (fname) {
+				html += `Ảnh tileset hiện tại: '${fname}'.`;
+			}
+			wrap.innerHTML = html || 'Chưa có map/tileset.';
+		} catch {}
 	}
 
 	async handleIconFiles(event) {
@@ -2013,268 +2046,4 @@ class MapViewerApp {
 				this.log(`Tệp '${file.name}': Đang đọc ${count} NPC...`);
 				let localAddCount = 0;
 				for (let i = 0; i < count; i++) {
-					if (reader.eof) { this.log(`LỖI: Tệp '${file.name}' kết thúc sớm. Đã đọc ${i}/${count} NPC.`); break; }
-					const npc = { name: reader.readUTF(), menuTitle: reader.readUTF(), npcId: reader.readByte(), iconMiniMap: reader.readByte(), x: reader.readShort() + 12, y: reader.readShort(), type1: reader.readByte(), type2: reader.readByte(), direction: reader.readByte(), iconInteract: reader.readByte(), dialog: reader.readUTF(), flag1: reader.readByte(), flag2: reader.readByte() };
-					this.mapData.npcs.push(npc); localAddCount++;
-				}
-				this.log(`Đã tải thành công ${localAddCount} NPC từ tệp '${file.name}'.`);
-			} catch (e) { this.log(`LỖI: Không thể phân tích tệp NPC ${file.name}.`); console.error(`Failed to parse NPC file ${file.name}:`, e); }
-		}
-		this.log(`Hoàn tất. Tổng số NPC hiện tại: ${this.mapData.npcs.length}. Đang kết xuất lại.`);
-		this.render();
-	}
-
-	handleAddNpc() {
-		if (!this.mapData) { this.log("LỖI: Không thể thêm NPC khi chưa có bản đồ nào được tải."); return; }
-		const viewCenterX = (this.canvas.width / 2 - this.panX) / this.scale;
-		const viewCenterY = (this.canvas.height / 2 - this.panY) / this.scale;
-		const newNpc = { name: "New NPC", menuTitle: "Interact", dialog: "Hello!", npcId: this.mapData.npcs.length > 0 ? Math.max(...this.mapData.npcs.map(n => n.npcId)) + 1 : 1, x: Math.round(viewCenterX), y: Math.round(viewCenterY), iconMiniMap: 0, iconInteract: 0, type1: 0, type2: 0, direction: 2, flag1: 1, flag2: 0 };
-		this.mapData.npcs.push(newNpc);
-		this.selectedNpc = newNpc;
-		this.log(`Đã thêm NPC mới '${newNpc.name}' tại (${newNpc.x}, ${newNpc.y}).`);
-		this.showNpcEditor(newNpc, true);
-		this.render();
-	}
-
-	showNpcEditor(npc, isNew = false) {
-		this.currentEditingNpc = npc; this.isNewNpc = isNew; this.npcEditorTitle.textContent = isNew ? "Add New NPC" : `Edit NPC: ${npc.name}`;
-		for (const key in npc) { const inputEl = this.npcEditorForm.elements.namedItem(key); if (inputEl) inputEl.value = npc[key]; }
-		this.updateNpcEditorIconPreview('npc-iconMiniMap', 'minimap-icon-preview', 3000);
-		this.updateNpcEditorIconPreview('npc-iconInteract', 'interact-icon-preview', 3500);
-		this.npcEditorModal.style.display = 'block';
-	}
-
-	hideNpcEditor(wasCancelled = false) {
-		if (wasCancelled && this.isNewNpc && this.currentEditingNpc && this.mapData) {
-			const index = this.mapData.npcs.indexOf(this.currentEditingNpc);
-			if (index > -1) { this.mapData.npcs.splice(index, 1); }
-			this.log("Thao tác thêm NPC mới đã bị hủy.");
-			if (this.selectedNpc === this.currentEditingNpc) { this.selectedNpc = null; }
-			this.render();
-		}
-		this.npcEditorModal.style.display = 'none';
-		this.currentEditingNpc = null; this.isNewNpc = false;
-	}
-
-	handleNpcEditorSave() {
-		if (!this.currentEditingNpc) return;
-		const formData = new FormData(this.npcEditorForm);
-		for (const key of Object.keys(this.currentEditingNpc)) {
-			const value = formData.get(key);
-			if (value !== null) { const isNumeric = !['name', 'menuTitle', 'dialog'].includes(key); this.currentEditingNpc[key] = isNumeric ? Number(value) : value; }
-		}
-		this.log(`Đã cập nhật thông tin cho NPC '${this.currentEditingNpc.name}'.`);
-		this.hideNpcEditor(false);
-		this.render();
-	}
-
-	updateNpcEditorIconPreview(inputId, previewId, idBase) {
-		const inputElement = document.getElementById(inputId);
-		const previewElement = document.getElementById(previewId);
-		if (!inputElement || !previewElement) return;
-		previewElement.innerHTML = '';
-		const value = parseInt(inputElement.value, 10);
-		if (isNaN(value)) { previewElement.textContent = '?'; return; }
-		const finalIconId = idBase + value;
-		const iconImage = this.effectIcons.get(finalIconId);
-		if (iconImage && iconImage.complete) {
-			const r = this.getIconFrameRect(iconImage);
-			const c = document.createElement('canvas');
-			c.width = r.sw; c.height = r.sh;
-			const cctx = c.getContext('2d'); cctx.imageSmoothingEnabled = false;
-			cctx.drawImage(iconImage, r.sx, r.sy, r.sw, r.sh, 0, 0, r.sw, r.sh);
-			previewElement.appendChild(c);
-		}
-		else { previewElement.textContent = '?'; }
-	}
-
-	showNpcDialog(npc) {
-		this.hideNpcDialog();
-		const interactionIconId = 3500 + Number(npc.iconInteract);
-		const interactionIconImg = this.effectIcons.get(interactionIconId);
-		const container = document.createElement('div');
-		container.id = 'npc-interaction-dialog';
-		container.className = 'npc-dialog-container';
-		const dialogBox = document.createElement('div');
-		dialogBox.className = 'npc-dialog-box';
-		const header = document.createElement('div'); header.className = 'npc-dialog-header'; const title = document.createElement('h3'); title.textContent = npc.name; header.appendChild(title);
-		const content = document.createElement('div'); content.className = 'npc-dialog-content'; const text = document.createElement('p'); text.textContent = npc.dialog; content.appendChild(text);
-		const actions = document.createElement('div'); actions.className = 'npc-dialog-actions';
-		if (npc.menuTitle && String(npc.menuTitle).trim() !== '') { const mainButton = document.createElement('button'); mainButton.textContent = npc.menuTitle; actions.appendChild(mainButton); }
-		const closeButton = document.createElement('button'); closeButton.textContent = 'Đóng'; closeButton.onclick = () => this.hideNpcDialog(); actions.appendChild(closeButton);
-		dialogBox.appendChild(header); dialogBox.appendChild(content); dialogBox.appendChild(actions);
-		const portraitPanel = document.createElement('div'); portraitPanel.className = 'npc-dialog-portrait';
-		if (interactionIconImg && interactionIconImg.complete) {
-			const r = this.getIconFrameRect(interactionIconImg);
-			const scaleFactor = 2.5;
-			const canvas = document.createElement('canvas');
-			canvas.width = r.sw * scaleFactor; canvas.height = r.sh * scaleFactor;
-			const ctx = canvas.getContext('2d'); ctx.imageSmoothingEnabled = false;
-			ctx.drawImage(interactionIconImg, r.sx, r.sy, r.sw, r.sh, 0, 0, canvas.width, canvas.height);
-			portraitPanel.appendChild(canvas);
-		} else { const placeholder = document.createElement('div'); placeholder.textContent = `? ${interactionIconId}`; placeholder.className = 'icon-placeholder'; portraitPanel.appendChild(placeholder); }
-		container.appendChild(dialogBox); container.appendChild(portraitPanel); this.canvasContainer.appendChild(container);
-		const screenX = npc.x * this.scale + this.panX; const screenY = npc.y * this.scale + this.panY; const containerRect = this.canvasContainer.getBoundingClientRect(); const dialogRect = container.getBoundingClientRect();
-		let finalX = screenX - (dialogRect.width / 2); let finalY = screenY - dialogRect.height - 20;
-		if (finalX < 10) finalX = 10; if (finalX + dialogRect.width > containerRect.width - 10) finalX = containerRect.width - dialogRect.width - 10; if (finalY < 10) finalY = 10; if (finalY + dialogRect.height > containerRect.height - 10) finalY = containerRect.height - dialogRect.height - 10;
-		container.style.left = `${finalX}px`; container.style.top = `${finalY}px`;
-	}
-
-	hideNpcDialog() {
-		const dialog = document.getElementById('npc-interaction-dialog');
-		if (dialog) dialog.remove();
-	}
-
-	drawNpc(npc) {
-		const finalIconId = 3000 + (npc.iconMiniMap | 0);
-		const icon = this.effectIcons.get(finalIconId);
-		if (icon && icon.complete) {
-			const r = this.getIconFrameRect(icon);
-			this.ctx.drawImage(icon, r.sx, r.sy, r.sw, r.sh, npc.x, npc.y, r.sw, r.sh);
-			if (npc.name) {
-				this.ctx.fillStyle = '#ffffff';
-				this.ctx.font = `bold ${12 / this.scale}px sans-serif`;
-				this.ctx.textAlign = 'center';
-				this.ctx.strokeStyle = 'black';
-				this.ctx.lineWidth = 2 / this.scale;
-				const textX = npc.x + r.sw / 2;
-				const textY = npc.y - 5 / this.scale;
-				this.ctx.strokeText(npc.name, textX, textY);
-				this.ctx.fillText(npc.name, textX, textY);
-			}
-			if (this.isNpcEditingMode && npc === this.selectedNpc) { this.ctx.strokeStyle = '#ffff00'; this.ctx.lineWidth = 2 / this.scale; this.ctx.strokeRect(npc.x, npc.y, r.sw, r.sh); }
-		} else {
-			this.ctx.fillStyle = 'rgba(148, 0, 211, 0.5)'; this.ctx.strokeStyle = '#9400D3'; this.ctx.lineWidth = 1 / this.scale; this.ctx.fillRect(npc.x, npc.y, TILE_SIZE, TILE_SIZE); this.ctx.strokeRect(npc.x, npc.y, TILE_SIZE, TILE_SIZE);
-		}
-	}
-
-	handleSaveNpcs() {
-		if (!this.mapData || this.mapData.npcs.length === 0) { this.log("CẢNH BÁO: Không có NPC nào để lưu."); return; }
-		this.log(`Bắt đầu lưu ${this.mapData.npcs.length} NPC...`);
-		try {
-			const writer = new BinaryWriter(); writer.writeByte(this.mapData.npcs.length);
-			for (const npc of this.mapData.npcs) {
-				writer.writeUTF(npc.name);
-				writer.writeUTF(npc.menuTitle);
-				writer.writeByte(npc.npcId);
-				writer.writeByte(npc.iconMiniMap);
-				writer.writeShort((npc.x | 0) - 12);
-				writer.writeShort(npc.y | 0);
-				writer.writeByte(npc.type1);
-				writer.writeByte(npc.type2);
-				writer.writeByte(npc.direction);
-				writer.writeByte(npc.iconInteract);
-				writer.writeUTF(npc.dialog);
-				writer.writeByte(npc.flag1);
-				writer.writeByte(npc.flag2);
-			}
-			const finalBuffer = writer.getBuffer();
-			const blob = new Blob([finalBuffer], { type: 'application/octet-stream' });
-			const a = document.createElement('a'); a.href = URL.createObjectURL(blob); a.download = `npc_data_${this.mapData.tilesetId}.dat`; document.body.appendChild(a); a.click(); document.body.removeChild(a); URL.revokeObjectURL(a.href);
-			this.log(`Hoàn tất! Tệp NPC '${a.download}' đã được tạo.`);
-		} catch (error) { this.log(`LỖI nghiêm trọng trong quá trình lưu NPC: ${error}`); console.error("Failed to save NPC file:", error); }
-	}
-
-			computeNpcVerticalSlices(img) {
-			try {
-				const w = img?.width || TILE_SIZE;
-				const h = img?.height || TILE_SIZE;
-				const ratio = h / Math.max(1, w);
-				// Detect midline seam (2-frame) for ambiguous tall sprites (e.g., 22x88, 25x88)
-				let frames = 1;
-				const r = ratio;
-				let forceTwo = false;
-				if (r >= 3.0 && r <= 4.2) {
-					try {
-						const c = document.createElement('canvas'); c.width = w; c.height = h; const ctx = c.getContext('2d'); ctx.imageSmoothingEnabled = false; ctx.drawImage(img, 0, 0);
-						const data = ctx.getImageData(0, 0, w, h).data;
-						const stripeAvg = (cy) => { const band = Math.max(1, Math.round(h * 0.04)); let sum = 0, cnt = 0; const y0 = Math.max(0, cy - band), y1 = Math.min(h - 1, cy + band); for (let y = y0; y <= y1; y++) { let o = y * w * 4 + 3; let s = 0; for (let x = 0; x < w; x++) { s += data[o]; o += 4; } sum += s / (255 * w); cnt++; } return cnt > 0 ? sum / cnt : 1; };
-						const mid = Math.floor(h / 2), q1 = Math.floor(h / 4), q3 = Math.floor((3 * h) / 4);
-						const m = stripeAvg(mid), a = stripeAvg(q1), b = stripeAvg(q3);
-						if (m <= Math.min(a, b) - 0.06) forceTwo = true;
-					} catch {}
-				}
-				if (forceTwo) {
-					frames = 2;
-				} else {
-					// Prefer divisibility; special-case small-width sprites
-					const isSmall = w <= 24;
-					const near = (x, y, tol) => Math.abs(x - y) <= tol;
-					if ((h % 4 === 0 || near(r, 4, 0.05)) && ((isSmall && r >= 3.8) || (!isSmall && r >= 3.1))) frames = 4;
-					else if ((h % 2 === 0 || near(r, 2, 0.05)) && r >= 1.45) frames = 2;
-					else if ((isSmall && r >= 3.8) || (!isSmall && r >= 3.35)) frames = 4;
-					else if (r >= 1.45) frames = 2;
-					else frames = 1;
-				}
-				const slices = [];
-				if (frames === 1) { slices.push({ sy: 0, sh: h }); return slices; }
-				const per = Math.floor(h / frames);
-				const rem = h - per * frames;
-				let y0 = 0;
-				for (let i = 0; i < frames; i++) {
-					const extra = i < rem ? 1 : 0;
-					const sh = per + extra;
-					slices.push({ sy: y0, sh: Math.max(1, sh) });
-					y0 += sh;
-				}
-				return slices;
-			} catch { return [{ sy: 0, sh: img?.height || TILE_SIZE }]; }
-		}
-
-		getIconFrameRect(img) {
-			const w = img?.width || TILE_SIZE; const h = img?.height || TILE_SIZE;
-			let cache = this.npcFrameCache.get(img);
-			if (!cache || cache.w !== w || cache.h !== h || !Array.isArray(cache.slices)) {
-				const slices = this.computeNpcVerticalSlices(img);
-				cache = { w, h, frames: slices.length, slices, start: (Date.now() % (this.animationTickMs * 1000)) };
-				this.npcFrameCache.set(img, cache);
-			}
-			const frames = cache.frames; const slices = cache.slices;
-			const elapsed = Date.now() - (cache.start || 0);
-			const idx = frames > 1 ? Math.floor(elapsed / this.animationTickMs) % frames : 0;
-			const sl = slices[idx] || { sy: 0, sh: h };
-			return { sx: 0, sy: sl.sy, sw: w, sh: sl.sh };
-		}
-
-	startAnimationLoop() {
-		if (this.animationTimer) clearInterval(this.animationTimer);
-		this.animationTimer = setInterval(() => { if (this.mapData) this.render(); }, this.animationTickMs);
-	}
-
-	async handleTilesetWaterFile(event) {
-		const input = event.target;
-		if (!input.files || input.files.length === 0) return;
-		const file = input.files[0];
-		const img = new Image();
-		img.onload = () => { this.tilesetWaterImage = img; this.log(`Đã nạp tilewater: ${file.name}`); };
-		img.onerror = () => { this.log(`LỖI: Không thể nạp tilewater '${file.name}'.`); this.tilesetWaterImage = null; };
-		img.src = URL.createObjectURL(file);
-	}
-
-	async handleTilesetSmallFile(event) {
-		const input = event.target;
-		if (!input.files || input.files.length === 0) return;
-		const file = input.files[0];
-		const img = new Image();
-		img.onload = () => { this.tilesetSmallImage = img; this.log(`Đã nạp tile_small: ${file.name}`); };
-		img.onerror = () => { this.log(`LỖI: Không thể nạp tile_small '${file.name}'.`); this.tilesetSmallImage = null; };
-		img.src = URL.createObjectURL(file);
-	}
-
-	exportTilesetExtras() {
-		if (!this.mapData) { this.log('Chưa có map để xuất water/small.'); return; }
-		const id = this.mapData.tilesetId | 0;
-		const downloadImg = (img, fname) => {
-			try { const c = document.createElement('canvas'); c.width = img.width; c.height = img.height; const x = c.getContext('2d'); x.imageSmoothingEnabled = false; x.drawImage(img, 0, 0); c.toBlob((blob) => { if (!blob) return; const a = document.createElement('a'); a.href = URL.createObjectURL(blob); a.download = fname; document.body.appendChild(a); a.click(); document.body.removeChild(a); setTimeout(()=>URL.revokeObjectURL(a.href), 500); }); } catch {}
-		};
-		let any = false;
-		if (this.tilesetWaterImage) { any = true; downloadImg(this.tilesetWaterImage, `tilewater${id}.png`); downloadImg(this.tilesetWaterImage, `102_${id}.png`); }
-		if (this.tilesetSmallImage) { any = true; downloadImg(this.tilesetSmallImage, `tile_small${id}.png`); downloadImg(this.tilesetSmallImage, `101_${id}.png`); }
-		if (!any) this.log('Chưa nạp ảnh water/small để xuất.'); else this.log('Đã xuất water/small theo ID hiện tại.');
-	}
-}
-
-new MapViewerApp();
-	</script>
-</body>
-</html>
+					if (reader.eof) { this.log(`LỖI: Tệp '${file.name}' kết thúc sớm. Đã đọc ${i}/${count} NPC.`

--- a/EDITMAPv6.html
+++ b/EDITMAPv6.html
@@ -2154,10 +2154,17 @@ class MapViewerApp {
 					// Thử phát hiện 2-frame bằng seam ở giữa; nếu seam yếu, coi như 1-frame
 					const margin = Math.round(h * 0.12);
 					const s = findSeamBetween(margin, h - margin);
-					const midBand = Math.max(1, Math.round(h * 0.06));
-					let seamStrength = 1e9; for (let y = Math.max(1, s - midBand); y <= Math.min(h - 2, s + midBand); y++) seamStrength = Math.min(seamStrength, smoothed[y]);
+					const band = Math.max(1, Math.round(h * 0.05));
+					let centerSum = 0, centerN = 0; for (let y = Math.max(1, s - band); y <= Math.min(h - 2, s + band); y++) { centerSum += smoothed[y]; centerN++; }
+					const centerAvg = centerN > 0 ? centerSum / centerN : 1;
+					let leftSum = 0, leftN = 0; const leftEnd = Math.max(1, s - band); const leftStart = Math.max(1, leftEnd - Math.round(h * 0.12)); for (let y = leftStart; y < leftEnd; y++) { leftSum += smoothed[y]; leftN++; }
+					let rightSum = 0, rightN = 0; const rightStart = Math.min(h - 2, s + band + 1); const rightEnd = Math.min(h - 2, rightStart + Math.round(h * 0.12)); for (let y = rightStart; y <= rightEnd; y++) { rightSum += smoothed[y]; rightN++; }
+					const leftAvg = leftN > 0 ? leftSum / leftN : 1;
+					const rightAvg = rightN > 0 ? rightSum / rightN : 1;
+					const sideAvg = Math.min(leftAvg, rightAvg);
 					const balance = Math.abs((s / h) - 0.5);
-					if (seamStrength <= 0.12 || balance <= 0.08) {
+					const accept = (centerAvg <= 0.18 && (sideAvg - centerAvg) >= 0.06) || (centerAvg <= sideAvg * 0.7) || (balance <= 0.08 && centerAvg <= 0.35);
+					if (accept) {
 						slices.push({ sy: 0, sh: Math.max(1, s) });
 						slices.push({ sy: s + 1, sh: Math.max(1, h - s - 1) });
 					} else {

--- a/EDITMAPv6.html
+++ b/EDITMAPv6.html
@@ -534,10 +534,11 @@ class MapViewerApp {
 	
 	mapData = null;
 	tilesetImage = null;
-			effectIcons = new Map();
-		npcFrameCache = new WeakMap();
-		originalMapFileName = '';
-		showOverlays = true;
+	tilesetLibrary = { main: new Map(), water: new Map(), small: new Map() };
+	effectIcons = new Map();
+	npcFrameCache = new WeakMap();
+	originalMapFileName = '';
+	showOverlays = true;
 	animationTickMs = 160;
 	animationTimer = null;
 
@@ -756,8 +757,21 @@ class MapViewerApp {
 						<input type="file" id="fp-tileset-input" accept=".png">
 					</div>
 					<div class="file-input-group">
-						<label for="fp-icon-input">Ảnh Icons (.png)</label>
-						<input type="file" id="fp-icon-input" accept=".png" multiple webkitdirectory directory>
+						<label for="fp-tileset-lib">Thư viện Tileset (chọn thư mục chứa tile{id}.png, tilewater{id}.png, tile_small{id}.png)</label>
+						<input type="file" id="fp-tileset-lib" accept=".png" multiple webkitdirectory directory>
+					</div>
+					<div class="grid-2" style="gap:8px; align-items:end;">
+						<div>
+							<label for="fp-tileset-id-override">Áp dụng tileset theo ID</label>
+							<input type="number" id="fp-tileset-id-override" min="0" step="1" placeholder="VD: 9" />
+							<div class="inline" style="margin-top:6px; gap:6px;">
+								<input type="checkbox" id="fp-tileset-update-mapid" />
+								<label for="fp-tileset-update-mapid">Cập nhật tilesetId của map</label>
+							</div>
+						</div>
+						<div class="inline" style="gap:6px;">
+							<button id="fp-apply-tileset-id" class="action-button">Áp dụng</button>
+						</div>
 					</div>
 					<div class="inline" style="gap: 8px;">
 						<button id="fp-save-map-button" class="action-button" ${this.mapData ? '' : 'disabled'}>Lưu Dữ Liệu (CMD 12)</button>
@@ -765,6 +779,14 @@ class MapViewerApp {
 				`;
 				document.getElementById('fp-map-input')?.addEventListener('change', this.handleMapFile.bind(this));
 				document.getElementById('fp-tileset-input')?.addEventListener('change', this.handleTilesetFile.bind(this));
+				document.getElementById('fp-tileset-lib')?.addEventListener('change', this.handleTilesetLibrary.bind(this));
+				document.getElementById('fp-apply-tileset-id')?.addEventListener('click', () => {
+					const idEl = document.getElementById('fp-tileset-id-override');
+					const updEl = document.getElementById('fp-tileset-update-mapid');
+					const id = Math.max(0, parseInt(idEl?.value || '0', 10) || 0);
+					const update = !!(updEl && updEl.checked);
+					this.applyTilesetById(id, update);
+				});
 				document.getElementById('fp-icon-input')?.addEventListener('change', this.handleIconFiles.bind(this));
 				document.getElementById('fp-save-map-button')?.addEventListener('click', this.handleSaveMap.bind(this));
 				break;
@@ -1030,6 +1052,10 @@ class MapViewerApp {
 			this.mapData.height = reader.readByte();
 			this.mapData.tilesetId = reader.readByte();
 			this.log(`Thông tin map:\n- Tên: ${this.mapData.mapName}\n- Kích thước: ${this.mapData.width}x${this.mapData.height}\n- Tileset ID: ${this.mapData.tilesetId}\n- Version: 0x${this.mapData.mapVersion.toString(16).toUpperCase()}`);
+			// Nếu đã có thư viện tileset, tự áp dụng theo ID map
+			if (this.tilesetLibrary && this.tilesetLibrary.main && this.tilesetLibrary.main.size > 0) {
+				this.applyTilesetById(this.mapData.tilesetId, false);
+			}
 			this.mapData.tileMap = [];
 			const tileData = reader.readBytes(this.mapData.width * this.mapData.height);
 			for (let y = 0; y < this.mapData.height; y++) {
@@ -2176,6 +2202,50 @@ class MapViewerApp {
 	startAnimationLoop() {
 		if (this.animationTimer) clearInterval(this.animationTimer);
 		this.animationTimer = setInterval(() => { if (this.mapData) this.render(); }, this.animationTickMs);
+	}
+
+	async handleTilesetLibrary(event) {
+		const input = event.target;
+		if (!input.files) return;
+		const files = Array.from(input.files);
+		if (files.length === 0) { this.log('Không có file tileset nào được chọn.'); return; }
+		let loaded = 0, skipped = 0;
+		const loadImg = (file) => new Promise((resolve, reject) => { const img = new Image(); img.onload = () => resolve(img); img.onerror = reject; img.src = URL.createObjectURL(file); });
+		for (const f of files) {
+			const name = (f.webkitRelativePath || f.name || '').replace(/\\/g,'/');
+			const base = name.substring(name.lastIndexOf('/')+1).toLowerCase();
+			const match = base.match(/^(tilewater|tile_small|tilesmall|tile)(\d+)\.png$/i);
+			if (!match) { skipped++; continue; }
+			const kindRaw = match[1];
+			const id = parseInt(match[2], 10);
+			if (!Number.isFinite(id)) { skipped++; continue; }
+			let kind = 'main';
+			if (kindRaw === 'tilewater') kind = 'water';
+			else if (kindRaw === 'tile_small' || kindRaw === 'tilesmall') kind = 'small';
+			try {
+				const img = await loadImg(f);
+				this.tilesetLibrary[kind].set(id, img);
+				loaded++;
+			} catch { skipped++; }
+		}
+		this.log(`Thư viện tileset: đã tải ${loaded} ảnh, bỏ qua ${skipped}.`);
+		// Auto-apply nếu map đang mở
+		if (this.mapData && this.tilesetLibrary.main.has(this.mapData.tilesetId)) {
+			this.applyTilesetById(this.mapData.tilesetId, false);
+		}
+	}
+
+	applyTilesetById(id, updateMapId = false) {
+		const img = this.tilesetLibrary?.main?.get(id);
+		if (!img) { this.log(`Không tìm thấy tile${id}.png trong thư viện.`); return; }
+		this.tilesetImage = img;
+		if (this.mapData && updateMapId) {
+			this.mapData.tilesetId = id | 0;
+			this.calculateCollisionMap();
+		}
+		this.populateTilePalette();
+		this.render();
+		this.log(`Đã áp dụng tileset từ thư viện: tile${id}.png${updateMapId ? ' (đã cập nhật tilesetId của map)' : ''}.`);
 	}
 }
 

--- a/EDITMAPv6.html
+++ b/EDITMAPv6.html
@@ -2121,8 +2121,9 @@ class MapViewerApp {
 				let frames = 1;
 				const r = ratio;
 				const isSmall = w <= 24;
-				if (h % 4 === 0 && ((isSmall && r >= 3.8) || (!isSmall && r >= 3.1))) frames = 4;
-				else if (h % 2 === 0 && r >= 1.45) frames = 2;
+				const near = (x, y, tol) => Math.abs(x - y) <= tol;
+				if ((h % 4 === 0 || near(r, 4, 0.05)) && ((isSmall && r >= 3.8) || (!isSmall && r >= 3.1))) frames = 4;
+				else if ((h % 2 === 0 || near(r, 2, 0.05)) && r >= 1.45) frames = 2;
 				else if ((isSmall && r >= 3.8) || (!isSmall && r >= 3.35)) frames = 4;
 				else if (r >= 1.45) frames = 2;
 				else frames = 1;

--- a/EDITMAPv6.html
+++ b/EDITMAPv6.html
@@ -1201,9 +1201,22 @@ class MapViewerApp {
 			const panel = document.getElementById('tile-palette-panel');
 			if (panel) panel.style.display = 'block';
 			this.render();
+			// Nếu người dùng đã nhập ID-only, cập nhật ngay mapId
+			const idOnly = document.getElementById('fp-tileset-id-only');
+			if (idOnly && this.mapData) { const id = Math.max(0, parseInt(idOnly.value || '', 10) || this.mapData.tilesetId); this.applyTilesetIdOnly(id); }
 		};
 		this.tilesetImage.onerror = () => { this.log(`LỖI: Không thể tải ảnh tileset '${file.name}'.`); this.tilesetImage = null; }
 		this.tilesetImage.src = URL.createObjectURL(file);
+	}
+
+	applyTilesetIdOnly(id) {
+		if (!this.mapData) { this.log('Chưa có map để cập nhật tilesetId.'); return; }
+		const newId = id | 0;
+		if (this.mapData.tilesetId === newId) { this.log(`tilesetId đã là ${newId}.`); return; }
+		this.mapData.tilesetId = newId;
+		this.calculateCollisionMap();
+		this.render();
+		this.log(`Đã cập nhật tilesetId của map thành ${newId}. Khi lưu, byte thứ 3 sẽ là ${newId}.`);
 	}
 
 	async handleIconFiles(event) {

--- a/EDITMAPv6.html
+++ b/EDITMAPv6.html
@@ -2117,31 +2117,10 @@ class MapViewerApp {
 				const w = img?.width || TILE_SIZE;
 				const h = img?.height || TILE_SIZE;
 				const ratio = h / Math.max(1, w);
-				// Stable detection: prefer exact divisibility, fall back to ratio thresholds
+				// Stable detection: simple ratio-based
 				let frames = 1;
-				if (h >= w * 1.2) {
-					if (h % 4 === 0 && ratio >= 3.0) frames = 4;
-					else if (h % 2 === 0 && ratio >= 2.1) frames = 2;
-					else {
-						const near = (x, y, tol) => Math.abs(x - y) <= tol;
-						if (near(ratio, 4, 0.25)) frames = 4;
-						else if (near(ratio, 2, 0.25)) frames = 2;
-						// Ambiguous band (~3.2-3.7 like 22x72, 26x86): probe alpha at midline to detect a clear 2-frame seam
-						else if (ratio > 3.0 && ratio < 3.8) {
-							try {
-								const c = document.createElement('canvas'); c.width = w; c.height = h; const ctx = c.getContext('2d'); ctx.imageSmoothingEnabled = false; ctx.drawImage(img, 0, 0);
-								const data = ctx.getImageData(0, 0, w, h).data;
-								const rowAlpha = (y) => { let s = 0; let o = y * w * 4 + 3; for (let x = 0; x < w; x++) { s += data[o]; o += 4; } return s / (255 * w); };
-								const mid = Math.floor(h / 2);
-								let center = 0; let cnt = 0; const band = Math.max(1, Math.round(h * 0.06));
-								for (let y = Math.max(1, mid - band); y <= Math.min(h - 2, mid + band); y++) { center += rowAlpha(y); cnt++; }
-								center = cnt > 0 ? center / cnt : 1;
-								// if center is much more transparent than neighbors, assume 2-frame
-								if (center <= 0.12) frames = 2; else frames = 4; // default to 4 when in doubt
-							} catch { frames = 4; }
-						}
-					}
-				}
+				const r = ratio;
+				if (r >= 3.9) frames = 4; else if (r >= 2.0) frames = 2; else frames = 1;
 				const slices = [];
 				if (frames === 1) { slices.push({ sy: 0, sh: h }); return slices; }
 				const per = Math.floor(h / frames);

--- a/EDITMAPv6.html
+++ b/EDITMAPv6.html
@@ -2112,22 +2112,23 @@ class MapViewerApp {
 	}
 
 			getIconFrameRect(img) {
-			// Dùng cho NPC: chỉ hỗ trợ sprite-sheet dọc với 2 hoặc 4 frame chuẩn.
+			// Dùng cho NPC: coi sprite-sheet dọc với 1/2/4 frame; ảnh tĩnh (1 frame) giữ nguyên.
 			const w = img?.width || TILE_SIZE;
 			const h = img?.height || TILE_SIZE;
 			let frames = 1;
 			if (w > 0 && h > 0) {
 				const ratio = h / w;
-				const n = Math.round(ratio);
-				if ((n === 2 || n === 4) && Math.abs(ratio - n) < 0.005 && (h % n === 0)) {
-					frames = n;
-				}
+				// Ngưỡng mềm: >=3.1 ~ 4 khung, >=1.5 ~ 2 khung, còn lại 1 khung
+				if (ratio >= 3.1) frames = 4;
+				else if (ratio >= 1.5) frames = 2;
+				else frames = 1;
 			}
 			let sx = 0, sy = 0, sw = w, sh = h;
 			if (frames > 1) {
 				const idx = Math.floor(Date.now() / this.animationTickMs) % frames;
-				sh = h / frames;
-				sy = idx * sh;
+				const per = Math.round(h / frames);
+				sy = Math.min(h - 1, Math.max(0, idx * per));
+				sh = Math.max(1, Math.min(h - sy, per));
 			}
 			return { sx, sy, sw, sh };
 		}

--- a/EDITMAPv6.html
+++ b/EDITMAPv6.html
@@ -758,11 +758,20 @@ class MapViewerApp {
 					</div>
 					<div class="grid-2" style="gap:8px; align-items:end;">
 						<div>
-							<label for="fp-tileset-id-only">Thiết lập tilesetId (byte thứ 3 của map)</label>
+							<label for="fp-tileset-id-only">Thiết lập tilesetId (byte thứ 3 của tileBlob)</label>
 							<input type="number" id="fp-tileset-id-only" min="0" step="1" placeholder="VD: 1" />
 						</div>
 						<div class="inline" style="gap:6px;">
 							<button id="fp-apply-tileset-id-only" class="action-button">Cập nhật ID map</button>
+						</div>
+					</div>
+					<div class="grid-2" style="gap:8px; align-items:end;">
+						<div>
+							<label for="fp-header-b2">Header byte #2 (cột thứ 2 đầu file)</label>
+							<input type="number" id="fp-header-b2" min="0" max="255" step="1" placeholder="VD: 1" />
+						</div>
+						<div class="inline" style="gap:6px;">
+							<button id="fp-apply-header-b2" class="action-button">Cập nhật Header</button>
 						</div>
 					</div>
 					<div class="inline" style="gap: 8px;">
@@ -775,6 +784,12 @@ class MapViewerApp {
 					const idEl = document.getElementById('fp-tileset-id-only');
 					const id = Math.max(0, parseInt(idEl?.value || '0', 10) || 0);
 					this.applyTilesetIdOnly(id);
+				});
+				document.getElementById('fp-apply-header-b2')?.addEventListener('click', () => {
+					const b2El = document.getElementById('fp-header-b2');
+					const v = Math.max(0, Math.min(255, parseInt(b2El?.value || '0', 10) || 0));
+					this.headerByte2 = v;
+					this.log(`Đã cập nhật header byte #2 = ${v}. Sẽ lưu vào hai byte đầu file.`);
 				});
 				document.getElementById('fp-icon-input')?.addEventListener('change', this.handleIconFiles.bind(this));
 				document.getElementById('fp-save-map-button')?.addEventListener('click', this.handleSaveMap.bind(this));
@@ -1034,13 +1049,15 @@ class MapViewerApp {
 			this.mapData = new MapData();
 			const reader = new BinaryReader(buffer);
 			this.log("Đang phân tích dữ liệu file map...");
+			// Đọc 2 byte đầu để hỗ trợ chỉnh header
+			try { const dv = new DataView(buffer); this.headerByte1 = dv.getUint8(0); this.headerByte2 = dv.getUint8(1); } catch {}
 			reader.seek(2);
 			this.mapData.mapName = reader.readUTF();
 			this.mapData.mapVersion = reader.readShort();
 			this.mapData.width = reader.readByte();
 			this.mapData.height = reader.readByte();
 			this.mapData.tilesetId = reader.readByte();
-			this.log(`Thông tin map:\n- Tên: ${this.mapData.mapName}\n- Kích thước: ${this.mapData.width}x${this.mapData.height}\n- Tileset ID: ${this.mapData.tilesetId}\n- Version: 0x${this.mapData.mapVersion.toString(16).toUpperCase()}`);
+			this.log(`Thông tin map:\n- Tên: ${this.mapData.mapName}\n- Kích thước: ${this.mapData.width}x${this.mapData.height}\n- Tileset ID: ${this.mapData.tilesetId}\n- Header[0..1]=(${this.headerByte1}, ${this.headerByte2})\n- Version: 0x${this.mapData.mapVersion.toString(16).toUpperCase()}`);
 			// Nếu đã có thư viện tileset, tự áp dụng theo ID map
 			if (this.tilesetLibrary && this.tilesetLibrary.main && this.tilesetLibrary.main.size > 0) {
 				this.applyTilesetById(this.mapData.tilesetId);
@@ -1287,7 +1304,9 @@ class MapViewerApp {
 			for (const [keyBytes, valBytes] of pairs) { overlayWriter.writeByte(keyBytes.length); overlayWriter.writeBytes(keyBytes); overlayWriter.writeByte(valBytes.length); overlayWriter.writeBytes(valBytes); }
 			const overlayBlob = new Uint8Array(overlayWriter.getBuffer());
 			const out = new BinaryWriter();
-			out.writeShort(0);
+			// Ghi 2 byte header tuỳ biến
+			out.writeByte(this.headerByte1 | 0);
+			out.writeByte(this.headerByte2 | 0);
 			out.writeUTF(this.mapData.mapName || "");
 			out.writeShort(tileBlob.length);
 			out.writeBytes(tileBlob);

--- a/EDITMAPv6.html
+++ b/EDITMAPv6.html
@@ -2117,7 +2117,8 @@ class MapViewerApp {
 				const w = img?.width || TILE_SIZE;
 				const h = img?.height || TILE_SIZE;
 				const ratio = h / Math.max(1, w);
-				let frames = (ratio >= 3.1) ? 4 : ((ratio >= 1.3) ? 2 : 1);
+				const near = (x, y, tol) => Math.abs(x - y) <= tol;
+				let frames = near(ratio, 4, 0.5) ? 4 : (near(ratio, 2, 0.35) ? 2 : 1);
 				if (frames === 1) return [{ sy: 0, sh: h }];
 				const c = document.createElement('canvas'); c.width = w; c.height = h; const ctx = c.getContext('2d'); ctx.imageSmoothingEnabled = false; ctx.drawImage(img, 0, 0);
 				const data = ctx.getImageData(0, 0, w, h).data;

--- a/EDITMAPv6.html
+++ b/EDITMAPv6.html
@@ -2117,9 +2117,8 @@ class MapViewerApp {
 				const w = img?.width || TILE_SIZE;
 				const h = img?.height || TILE_SIZE;
 				const ratio = h / Math.max(1, w);
-				const near = (x, y, tol) => Math.abs(x - y) <= tol;
-				let frames = near(ratio, 4, 0.5) ? 4 : (near(ratio, 2, 0.35) ? 2 : 1);
-				if (frames === 1) return [{ sy: 0, sh: h }];
+				let frames = (ratio >= 3.1) ? 4 : 1;
+				// không return sớm; sẽ thử dò seam giữa ảnh để xác nhận 2-frame, nếu không được thì giữ 1-frame
 				const c = document.createElement('canvas'); c.width = w; c.height = h; const ctx = c.getContext('2d'); ctx.imageSmoothingEnabled = false; ctx.drawImage(img, 0, 0);
 				const data = ctx.getImageData(0, 0, w, h).data;
 				const solidRow = new Float32Array(h);
@@ -2144,17 +2143,24 @@ class MapViewerApp {
 					return seam;
 				};
 				const slices = [];
-				if (frames === 2) {
-					const margin = Math.round(h * 0.12);
-					const s = findSeamBetween(margin, h - margin);
-					slices.push({ sy: 0, sh: Math.max(1, s) });
-					slices.push({ sy: s + 1, sh: Math.max(1, h - s - 1) });
-				} else {
-					// 4-frame: quay về cắt đều để đảm bảo ổn định như trước (không dò seam)
+				if (frames === 4) {
+					// 4-frame ổn định: chia đều theo chiều cao
 					const per = Math.floor(h / 4);
 					const rem = h - per * 4;
 					let y0 = 0;
 					for (let i = 0; i < 4; i++) { const extra = i < rem ? 1 : 0; const sh = per + extra; slices.push({ sy: y0, sh }); y0 += sh; }
+				} else {
+					// Thử phát hiện 2-frame bằng seam ở giữa; nếu seam yếu, coi như 1-frame
+					const margin = Math.round(h * 0.12);
+					const s = findSeamBetween(margin, h - margin);
+					const midBand = Math.max(1, Math.round(h * 0.05));
+					let seamStrength = 1e9; for (let y = Math.max(1, s - midBand); y <= Math.min(h - 2, s + midBand); y++) seamStrength = Math.min(seamStrength, smoothed[y]);
+					if (seamStrength <= 0.08) {
+						slices.push({ sy: 0, sh: Math.max(1, s) });
+						slices.push({ sy: s + 1, sh: Math.max(1, h - s - 1) });
+					} else {
+						slices.push({ sy: 0, sh: h });
+					}
 				}
 				const minSh = Math.max(1, Math.floor(h / (frames * 4)));
 				if (slices.length !== frames || slices.some(s => s.sh < minSh)) { slices.length = 0; const per = Math.floor(h / frames); const rem = h - per * frames; let y0 = 0; for (let i = 0; i < frames; i++) { const extra = i < rem ? 1 : 0; const sh = per + extra; slices.push({ sy: y0, sh }); y0 += sh; } }

--- a/EDITMAPv6.html
+++ b/EDITMAPv6.html
@@ -537,6 +537,8 @@ class MapViewerApp {
 	effectIcons = new Map();
 	originalMapFileName = '';
 	showOverlays = true;
+	animationTickMs = 160;
+	animationTimer = null;
 
 	scale = 1.0;
 	panX = 0;
@@ -609,6 +611,7 @@ class MapViewerApp {
 		this.topUndoButton = document.getElementById('top-undo-btn');
 		if (this.topUndoButton) { this.topUndoButton.addEventListener('click', this.handleUndo.bind(this)); this.topUndoButton.disabled = true; }
 		this.log("Map viewer đã khởi tạo. Sẵn sàng nhận file.");
+		this.startAnimationLoop();
 	}
 
 	log(message) {
@@ -1576,27 +1579,29 @@ class MapViewerApp {
 		if (eff.text) { this.ctx.fillStyle = '#ffffff'; this.ctx.font = `bold ${14 / this.scale}px sans-serif`; this.ctx.textAlign = 'center'; this.ctx.textBaseline = 'middle'; this.ctx.strokeStyle = 'black'; this.ctx.lineWidth = 3 / this.scale; const textX = eff.x + TILE_SIZE / 2; const textY = eff.y + TILE_SIZE / 2; this.ctx.strokeText(eff.text, textX, textY); this.ctx.fillText(eff.text, textX, textY); }
 	}
 	
-	drawEffect(effect) {
-		const icon = this.effectIcons.get(effect.templateId);
-		if (icon && icon.complete) {
-			const drawX = effect.x + (TILE_SIZE - icon.width) / 2;
-			const drawY = effect.y + (TILE_SIZE - icon.height) / 2;
-			this.ctx.drawImage(icon, drawX, drawY, icon.width, icon.height);
-		} else {
-			this.ctx.fillStyle = 'rgba(255, 255, 0, 0.5)';
-			this.ctx.strokeStyle = '#cccc00';
-			this.ctx.lineWidth = 1 / this.scale;
-			this.ctx.fillRect(effect.x, effect.y, TILE_SIZE, TILE_SIZE);
-			this.ctx.strokeRect(effect.x, effect.y, TILE_SIZE, TILE_SIZE);
+			drawEffect(effect) {
+			const icon = this.effectIcons.get(effect.templateId);
+			if (icon && icon.complete) {
+				const r = this.getIconFrameRect(icon);
+				const drawX = effect.x + (TILE_SIZE - r.sw) / 2;
+				const drawY = effect.y + (TILE_SIZE - r.sh) / 2;
+				this.ctx.drawImage(icon, r.sx, r.sy, r.sw, r.sh, drawX, drawY, r.sw, r.sh);
+			} else {
+				this.ctx.fillStyle = 'rgba(255, 255, 0, 0.5)';
+				this.ctx.strokeStyle = '#cccc00';
+				this.ctx.lineWidth = 1 / this.scale;
+				this.ctx.fillRect(effect.x, effect.y, TILE_SIZE, TILE_SIZE);
+				this.ctx.strokeRect(effect.x, effect.y, TILE_SIZE, TILE_SIZE);
+			}
+			if (this.isIconEditingMode && this.selectedEffectObject === effect) {
+				const rSel = icon && icon.complete ? this.getIconFrameRect(icon) : { sx:0, sy:0, sw:TILE_SIZE, sh:TILE_SIZE };
+				const w = rSel.sw;
+				const h = rSel.sh;
+				const x = (icon && icon.complete) ? (effect.x + (TILE_SIZE - rSel.sw) / 2) : effect.x;
+				const y = (icon && icon.complete) ? (effect.y + (TILE_SIZE - rSel.sh) / 2) : effect.y;
+				this.highlightSelection(x, y, w, h);
+			}
 		}
-		if (this.isIconEditingMode && this.selectedEffectObject === effect) {
-			const w = (icon && icon.complete) ? icon.width : TILE_SIZE;
-			const h = (icon && icon.complete) ? icon.height : TILE_SIZE;
-			const x = (icon && icon.complete) ? (effect.x + (TILE_SIZE - icon.width) / 2) : effect.x;
-			const y = (icon && icon.complete) ? (effect.y + (TILE_SIZE - icon.height) / 2) : effect.y;
-			this.highlightSelection(x, y, w, h);
-		}
-	}
 
 	// Tile palette & editing
 	populateTilePalette() {
@@ -1672,7 +1677,7 @@ class MapViewerApp {
 			const npc = this.mapData.npcs[i];
 			const icon = this.effectIcons.get(3000 + (npc.iconMiniMap | 0));
 			let w = TILE_SIZE, h = TILE_SIZE;
-			if (icon && icon.complete) { w = icon.width; h = icon.height; }
+			if (icon && icon.complete) { const r = this.getIconFrameRect(icon); w = r.sw; h = r.sh; }
 			if (mx >= npc.x && mx <= npc.x + w && my >= npc.y && my <= npc.y + h) return npc;
 		}
 		return null;
@@ -2010,7 +2015,14 @@ class MapViewerApp {
 		if (isNaN(value)) { previewElement.textContent = '?'; return; }
 		const finalIconId = idBase + value;
 		const iconImage = this.effectIcons.get(finalIconId);
-		if (iconImage && iconImage.complete) { const img = document.createElement('img'); img.src = iconImage.src; previewElement.appendChild(img); }
+		if (iconImage && iconImage.complete) {
+			const r = this.getIconFrameRect(iconImage);
+			const c = document.createElement('canvas');
+			c.width = r.sw; c.height = r.sh;
+			const cctx = c.getContext('2d'); cctx.imageSmoothingEnabled = false;
+			cctx.drawImage(iconImage, r.sx, r.sy, r.sw, r.sh, 0, 0, r.sw, r.sh);
+			previewElement.appendChild(c);
+		}
 		else { previewElement.textContent = '?'; }
 	}
 
@@ -2031,7 +2043,13 @@ class MapViewerApp {
 		dialogBox.appendChild(header); dialogBox.appendChild(content); dialogBox.appendChild(actions);
 		const portraitPanel = document.createElement('div'); portraitPanel.className = 'npc-dialog-portrait';
 		if (interactionIconImg && interactionIconImg.complete) {
-			const iconToDraw = interactionIconImg; const scaleFactor = 2.5; const canvas = document.createElement('canvas'); canvas.width = iconToDraw.width * scaleFactor; canvas.height = iconToDraw.height * scaleFactor; const ctx = canvas.getContext('2d'); ctx.imageSmoothingEnabled = false; ctx.drawImage(iconToDraw, 0, 0, iconToDraw.width, iconToDraw.height, 0, 0, canvas.width, canvas.height); portraitPanel.appendChild(canvas);
+			const r = this.getIconFrameRect(interactionIconImg);
+			const scaleFactor = 2.5;
+			const canvas = document.createElement('canvas');
+			canvas.width = r.sw * scaleFactor; canvas.height = r.sh * scaleFactor;
+			const ctx = canvas.getContext('2d'); ctx.imageSmoothingEnabled = false;
+			ctx.drawImage(interactionIconImg, r.sx, r.sy, r.sw, r.sh, 0, 0, canvas.width, canvas.height);
+			portraitPanel.appendChild(canvas);
 		} else { const placeholder = document.createElement('div'); placeholder.textContent = `? ${interactionIconId}`; placeholder.className = 'icon-placeholder'; portraitPanel.appendChild(placeholder); }
 		container.appendChild(dialogBox); container.appendChild(portraitPanel); this.canvasContainer.appendChild(container);
 		const screenX = npc.x * this.scale + this.panX; const screenY = npc.y * this.scale + this.panY; const containerRect = this.canvasContainer.getBoundingClientRect(); const dialogRect = container.getBoundingClientRect();
@@ -2049,10 +2067,20 @@ class MapViewerApp {
 		const finalIconId = 3000 + (npc.iconMiniMap | 0);
 		const icon = this.effectIcons.get(finalIconId);
 		if (icon && icon.complete) {
-			const w = icon.width; const h = icon.height;
-			this.ctx.drawImage(icon, npc.x, npc.y, w, h);
-			if (npc.name) { this.ctx.fillStyle = '#ffffff'; this.ctx.font = `bold ${12 / this.scale}px sans-serif`; this.ctx.textAlign = 'center'; this.ctx.strokeStyle = 'black'; this.ctx.lineWidth = 2 / this.scale; const textX = npc.x + w / 2; const textY = npc.y - 5 / this.scale; this.ctx.strokeText(npc.name, textX, textY); this.ctx.fillText(npc.name, textX, textY); }
-			if (this.isNpcEditingMode && npc === this.selectedNpc) { this.ctx.strokeStyle = '#ffff00'; this.ctx.lineWidth = 2 / this.scale; this.ctx.strokeRect(npc.x, npc.y, w, h); }
+			const r = this.getIconFrameRect(icon);
+			this.ctx.drawImage(icon, r.sx, r.sy, r.sw, r.sh, npc.x, npc.y, r.sw, r.sh);
+			if (npc.name) {
+				this.ctx.fillStyle = '#ffffff';
+				this.ctx.font = `bold ${12 / this.scale}px sans-serif`;
+				this.ctx.textAlign = 'center';
+				this.ctx.strokeStyle = 'black';
+				this.ctx.lineWidth = 2 / this.scale;
+				const textX = npc.x + r.sw / 2;
+				const textY = npc.y - 5 / this.scale;
+				this.ctx.strokeText(npc.name, textX, textY);
+				this.ctx.fillText(npc.name, textX, textY);
+			}
+			if (this.isNpcEditingMode && npc === this.selectedNpc) { this.ctx.strokeStyle = '#ffff00'; this.ctx.lineWidth = 2 / this.scale; this.ctx.strokeRect(npc.x, npc.y, r.sw, r.sh); }
 		} else {
 			this.ctx.fillStyle = 'rgba(148, 0, 211, 0.5)'; this.ctx.strokeStyle = '#9400D3'; this.ctx.lineWidth = 1 / this.scale; this.ctx.fillRect(npc.x, npc.y, TILE_SIZE, TILE_SIZE); this.ctx.strokeRect(npc.x, npc.y, TILE_SIZE, TILE_SIZE);
 		}
@@ -2083,6 +2111,34 @@ class MapViewerApp {
 			const a = document.createElement('a'); a.href = URL.createObjectURL(blob); a.download = `npc_data_${this.mapData.tilesetId}.dat`; document.body.appendChild(a); a.click(); document.body.removeChild(a); URL.revokeObjectURL(a.href);
 			this.log(`Hoàn tất! Tệp NPC '${a.download}' đã được tạo.`);
 		} catch (error) { this.log(`LỖI nghiêm trọng trong quá trình lưu NPC: ${error}`); console.error("Failed to save NPC file:", error); }
+	}
+
+	getIconFrameRect(img) {
+		const w = img?.width || TILE_SIZE;
+		const h = img?.height || TILE_SIZE;
+		let orientation = 'none';
+		if (h > w * 1.25) orientation = 'vertical';
+		else if (w > h * 1.25) orientation = 'horizontal';
+		let frames = 1;
+		if (orientation !== 'none') {
+			const ratio = orientation === 'vertical' ? h / w : w / h;
+			const candidates = [1,2,3,4,5,6,7,8];
+			frames = candidates.reduce((best, n) => (Math.abs(ratio - n) < Math.abs(ratio - best) ? n : best), 1);
+			if (frames < 1) frames = 1;
+		}
+		let sw = w, sh = h;
+		if (orientation === 'vertical') sh = Math.floor(h / frames);
+		else if (orientation === 'horizontal') sw = Math.floor(w / frames);
+		const index = frames > 1 ? Math.floor(Date.now() / this.animationTickMs) % frames : 0;
+		let sx = 0, sy = 0;
+		if (orientation === 'vertical') sy = index * sh;
+		else if (orientation === 'horizontal') sx = index * sw;
+		return { sx, sy, sw, sh };
+	}
+
+	startAnimationLoop() {
+		if (this.animationTimer) clearInterval(this.animationTimer);
+		this.animationTimer = setInterval(() => { if (this.mapData) this.render(); }, this.animationTickMs);
 	}
 }
 

--- a/EDITMAPv6.html
+++ b/EDITMAPv6.html
@@ -2112,33 +2112,54 @@ class MapViewerApp {
 		} catch (error) { this.log(`LỖI nghiêm trọng trong quá trình lưu NPC: ${error}`); console.error("Failed to save NPC file:", error); }
 	}
 
-			getIconFrameRect(img) {
-			// NPC only: cache per image to avoid inconsistent splits; support 1/2/4 vertical frames.
-			const cached = this.npcFrameCache.get(img);
-			const w = img?.width || TILE_SIZE;
-			const h = img?.height || TILE_SIZE;
-			let frames = 1;
-			if (cached && cached.w === w && cached.h === h) {
-				frames = cached.frames;
-			} else {
-				const ratio = h / w;
-				if (ratio >= 3.1) frames = 4;
-				else if (ratio >= 1.5) frames = 2;
-				else frames = 1;
-				this.npcFrameCache.set(img, { w, h, frames });
+			computeNpcVerticalSlices(img) {
+			try {
+				const w = img?.width || TILE_SIZE;
+				const h = img?.height || TILE_SIZE;
+				const ratio = h / Math.max(1, w);
+				let frames = (ratio >= 3.1) ? 4 : ((ratio >= 1.3) ? 2 : 1);
+				if (frames === 1) return [{ sy: 0, sh: h }];
+				const c = document.createElement('canvas'); c.width = w; c.height = h; const ctx = c.getContext('2d'); ctx.imageSmoothingEnabled = false; ctx.drawImage(img, 0, 0);
+				const data = ctx.getImageData(0, 0, w, h).data;
+				const alphaRow = new Float32Array(h);
+				for (let y = 0; y < h; y++) { let sum = 0; let o = y * w * 4 + 3; for (let x = 0; x < w; x++) { sum += data[o]; o += 4; } alphaRow[y] = sum / (255 * w); }
+				const clamp = (v, min, max) => Math.max(min, Math.min(max, v));
+				const window = Math.max(1, Math.round(h * 0.08));
+				const targets = frames === 2 ? [h / 2] : [h / 4, h / 2, (3 * h) / 4];
+				const seams = [];
+				for (const t of targets) {
+					let bestY = Math.round(t); let bestScore = Number.POSITIVE_INFINITY;
+					const s = clamp(Math.round(t) - window, 1, h - 2);
+					const e = clamp(Math.round(t) + window, 1, h - 2);
+					for (let y = s; y <= e; y++) {
+						const score = alphaRow[y];
+						if (score < bestScore) { bestScore = score; bestY = y; }
+					}
+					seams.push(bestY);
+				}
+				seams.sort((a,b)=>a-b);
+				for (let i=1;i<seams.length;i++) if (seams[i] <= seams[i-1]) seams[i] = Math.min(h-2, seams[i-1]+1);
+				const slices = [];
+				let prev = 0;
+				for (const sY of seams) { const sh = Math.max(1, sY - prev); slices.push({ sy: prev, sh }); prev = sY + 1; }
+				slices.push({ sy: prev, sh: Math.max(1, h - prev) });
+				if (slices.some(s => s.sh < Math.max(1, Math.floor(h / (frames * 4))))) {
+					slices.length = 0; const per = Math.floor(h / frames); const rem = h - per * frames; let y0 = 0; for (let i=0;i<frames;i++){ const extra = i < rem ? 1 : 0; const sh = per + extra; slices.push({ sy: y0, sh }); y0 += sh; }
+				}
+				return slices;
+			} catch { return [{ sy: 0, sh: img?.height || TILE_SIZE }]; }
+		}
+
+		getIconFrameRect(img) {
+			const w = img?.width || TILE_SIZE; const h = img?.height || TILE_SIZE;
+			let cache = this.npcFrameCache.get(img);
+			if (!cache || cache.w !== w || cache.h !== h || !Array.isArray(cache.slices)) {
+				const slices = this.computeNpcVerticalSlices(img);
+				cache = { w, h, frames: slices.length, slices };
+				this.npcFrameCache.set(img, cache);
 			}
-			let sx = 0, sy = 0, sw = w, sh = h;
-			if (frames > 1) {
-				const idx = Math.floor(Date.now() / this.animationTickMs) % frames;
-				const per = Math.floor(h / frames);
-				const remainder = h - per * frames;
-				// distribute remainder pixels to top frames to avoid missing bottom row
-				const extraForThis = Math.min(1, Math.max(0, idx < remainder ? 1 : 0));
-				const offsetExtras = Math.min(remainder, idx);
-				sy = idx * per + offsetExtras;
-				sh = per + extraForThis;
-			}
-			return { sx, sy, sw, sh };
+			const frames = cache.frames; const slices = cache.slices; const idx = frames > 1 ? Math.floor(Date.now() / this.animationTickMs) % frames : 0; const sl = slices[idx] || { sy: 0, sh: h };
+			return { sx: 0, sy: sl.sy, sw: w, sh: sl.sh };
 		}
 
 	startAnimationLoop() {

--- a/EDITMAPv6.html
+++ b/EDITMAPv6.html
@@ -2117,12 +2117,13 @@ class MapViewerApp {
 				const w = img?.width || TILE_SIZE;
 				const h = img?.height || TILE_SIZE;
 				const ratio = h / Math.max(1, w);
-				// Stable detection: prefer divisibility; then ratio thresholds for vertical sprites
+				// Stable detection: prefer divisibility; special-case small-width sprites
 				let frames = 1;
 				const r = ratio;
-				if (h % 4 === 0 && r >= 3.1) frames = 4;
+				const isSmall = w <= 24;
+				if (h % 4 === 0 && ((isSmall && r >= 3.8) || (!isSmall && r >= 3.1))) frames = 4;
 				else if (h % 2 === 0 && r >= 1.45) frames = 2;
-				else if (r >= 3.35) frames = 4;
+				else if ((isSmall && r >= 3.8) || (!isSmall && r >= 3.35)) frames = 4;
 				else if (r >= 1.45) frames = 2;
 				else frames = 1;
 				const slices = [];

--- a/EDITMAPv6.html
+++ b/EDITMAPv6.html
@@ -2113,28 +2113,38 @@ class MapViewerApp {
 		} catch (error) { this.log(`LỖI nghiêm trọng trong quá trình lưu NPC: ${error}`); console.error("Failed to save NPC file:", error); }
 	}
 
-	getIconFrameRect(img) {
-		const w = img?.width || TILE_SIZE;
-		const h = img?.height || TILE_SIZE;
-		let orientation = 'none';
-		if (h > w * 1.25) orientation = 'vertical';
-		else if (w > h * 1.25) orientation = 'horizontal';
-		let frames = 1;
-		if (orientation !== 'none') {
-			const ratio = orientation === 'vertical' ? h / w : w / h;
-			const candidates = [1,2,3,4,5,6,7,8];
-			frames = candidates.reduce((best, n) => (Math.abs(ratio - n) < Math.abs(ratio - best) ? n : best), 1);
-			if (frames < 1) frames = 1;
+			getIconFrameRect(img) {
+			const w = img?.width || TILE_SIZE;
+			const h = img?.height || TILE_SIZE;
+			let orientation = 'none';
+			if (h >= w + 2) orientation = 'vertical';
+			else if (w >= h + 2) orientation = 'horizontal';
+			const chooseFrames = (total, ortho) => {
+				const candidates = [2,3,4,5,6,8];
+				const tol = Math.max(1, Math.round(total * 0.02));
+				for (const f of candidates) { if (total % f <= tol) return f; }
+				let best = 1; let bestCost = Number.POSITIVE_INFINITY;
+				for (const f of candidates) { const seg = total / f; if (seg < 8) continue; const cost = Math.abs(seg - ortho); if (cost < bestCost) { bestCost = cost; best = f; } }
+				return best;
+			};
+			let frames = 1;
+			if (orientation === 'vertical') frames = chooseFrames(h, w);
+			else if (orientation === 'horizontal') frames = chooseFrames(w, h);
+			let sx = 0, sy = 0, sw = w, sh = h;
+			const idx = frames > 1 ? Math.floor(Date.now() / this.animationTickMs) % frames : 0;
+			if (orientation === 'vertical' && frames > 1) {
+				const start = Math.round(idx * h / frames);
+				const end = Math.round((idx + 1) * h / frames);
+				sy = start; sh = Math.max(1, end - start);
+			} else if (orientation === 'horizontal' && frames > 1) {
+				const start = Math.round(idx * w / frames);
+				const end = Math.round((idx + 1) * w / frames);
+				sx = start; sw = Math.max(1, end - start);
+			}
+			if (sx + sw > w) sw = w - sx;
+			if (sy + sh > h) sh = h - sy;
+			return { sx, sy, sw, sh };
 		}
-		let sw = w, sh = h;
-		if (orientation === 'vertical') sh = Math.floor(h / frames);
-		else if (orientation === 'horizontal') sw = Math.floor(w / frames);
-		const index = frames > 1 ? Math.floor(Date.now() / this.animationTickMs) % frames : 0;
-		let sx = 0, sy = 0;
-		if (orientation === 'vertical') sy = index * sh;
-		else if (orientation === 'horizontal') sx = index * sw;
-		return { sx, sy, sw, sh };
-	}
 
 	startAnimationLoop() {
 		if (this.animationTimer) clearInterval(this.animationTimer);

--- a/EDITMAPv6.html
+++ b/EDITMAPv6.html
@@ -2122,8 +2122,8 @@ class MapViewerApp {
 				const r = ratio;
 				if (h % 4 === 0 && r >= 3.1) frames = 4;
 				else if (h % 2 === 0 && r >= 1.45) frames = 2;
-				else if (r >= 3.4) frames = 4;
-				else if (r >= 1.5) frames = 2;
+				else if (r >= 3.35) frames = 4;
+				else if (r >= 1.45) frames = 2;
 				else frames = 1;
 				const slices = [];
 				if (frames === 1) { slices.push({ sy: 0, sh: h }); return slices; }

--- a/EDITMAPv6.html
+++ b/EDITMAPv6.html
@@ -2155,10 +2155,13 @@ class MapViewerApp {
 			let cache = this.npcFrameCache.get(img);
 			if (!cache || cache.w !== w || cache.h !== h || !Array.isArray(cache.slices)) {
 				const slices = this.computeNpcVerticalSlices(img);
-				cache = { w, h, frames: slices.length, slices };
+				cache = { w, h, frames: slices.length, slices, start: (Date.now() % (this.animationTickMs * 1000)) };
 				this.npcFrameCache.set(img, cache);
 			}
-			const frames = cache.frames; const slices = cache.slices; const idx = frames > 1 ? Math.floor(Date.now() / this.animationTickMs) % frames : 0; const sl = slices[idx] || { sy: 0, sh: h };
+			const frames = cache.frames; const slices = cache.slices;
+			const elapsed = Date.now() - (cache.start || 0);
+			const idx = frames > 1 ? Math.floor(elapsed / this.animationTickMs) % frames : 0;
+			const sl = slices[idx] || { sy: 0, sh: h };
 			return { sx: 0, sy: sl.sy, sw: w, sh: sl.sh };
 		}
 

--- a/EDITMAPv6.html
+++ b/EDITMAPv6.html
@@ -2121,34 +2121,45 @@ class MapViewerApp {
 				if (frames === 1) return [{ sy: 0, sh: h }];
 				const c = document.createElement('canvas'); c.width = w; c.height = h; const ctx = c.getContext('2d'); ctx.imageSmoothingEnabled = false; ctx.drawImage(img, 0, 0);
 				const data = ctx.getImageData(0, 0, w, h).data;
-				const alphaRow = new Float32Array(h);
-				for (let y = 0; y < h; y++) { let sum = 0; let o = y * w * 4 + 3; for (let x = 0; x < w; x++) { sum += data[o]; o += 4; } alphaRow[y] = sum / (255 * w); }
+				const solidRow = new Float32Array(h);
+				const A = 24;
+				for (let y = 0; y < h; y++) { let cnt = 0; let o = y * w * 4 + 3; for (let x = 0; x < w; x++) { if (data[o] >= A) cnt++; o += 4; } solidRow[y] = cnt / w; }
+				const k = Math.max(1, Math.round(h * 0.02));
+				const smoothed = new Float32Array(h);
+				for (let y = 0; y < h; y++) { let sum = 0, num = 0; const s = Math.max(0, y - k), e = Math.min(h - 1, y + k); for (let t = s; t <= e; t++) { sum += solidRow[t]; num++; } smoothed[y] = sum / Math.max(1, num); }
 				const clamp = (v, min, max) => Math.max(min, Math.min(max, v));
-				const window = Math.max(1, Math.round(h * 0.12));
-				const targets = frames === 2 ? [h / 2] : [h / 4, h / 2, (3 * h) / 4];
-				const seams = [];
-				for (const t of targets) {
-					let bestY = Math.round(t); let bestScore = Number.POSITIVE_INFINITY;
-					const s = clamp(Math.round(t) - window, 1, h - 2);
-					const e = clamp(Math.round(t) + window, 1, h - 2);
-					for (let y = s; y <= e; y++) {
-						// Ưu tiên đường cắt ở vùng trong suốt (alpha thấp) và ở giữa hai vùng đặc (biên gradient nhỏ)
-						const prev = Math.max(0, y - 1), next = Math.min(h - 1, y + 1);
-						const grad = Math.abs(alphaRow[next] - alphaRow[prev]);
-						const score = alphaRow[y] + grad * 0.25;
-						if (score < bestScore) { bestScore = score; bestY = y; }
-					}
-					seams.push(bestY);
-				}
-				seams.sort((a,b)=>a-b);
-				for (let i=1;i<seams.length;i++) if (seams[i] <= seams[i-1]) seams[i] = Math.min(h-2, seams[i-1]+1);
+				const findSeamBetween = (lo, hi) => {
+					const L = clamp(Math.floor(lo), 1, h - 2);
+					const R = clamp(Math.floor(hi), 1, h - 2);
+					let yMin = Math.floor((L + R) / 2); let best = Number.POSITIVE_INFINITY;
+					for (let y = L; y <= R; y++) { const prev = Math.max(0, y - 1), next = Math.min(h - 1, y + 1); const grad = Math.abs(smoothed[next] - smoothed[prev]); const score = smoothed[y] + grad * 0.3; if (score < best) { best = score; yMin = y; } }
+					const solidThr = Math.max(0.03, Math.min(0.15, best * 0.8));
+					let top = yMin; while (top > L && smoothed[top] <= solidThr) top--;
+					let bot = yMin; while (bot < R && smoothed[bot] <= solidThr) bot++;
+					let lastTop = top; while (lastTop >= L && solidRow[lastTop] <= solidThr) lastTop--;
+					let firstBot = bot; while (firstBot <= R && solidRow[firstBot] <= solidThr) firstBot++;
+					let seam = Math.floor((Math.max(L, lastTop) + Math.min(R, firstBot)) / 2);
+					seam = clamp(seam, L, R - 1);
+					return seam;
+				};
 				const slices = [];
-				let prev = 0;
-				for (const sY of seams) { const sh = Math.max(1, sY - prev); slices.push({ sy: prev, sh }); prev = sY + 1; }
-				slices.push({ sy: prev, sh: Math.max(1, h - prev) });
-				if (slices.some(s => s.sh < Math.max(1, Math.floor(h / (frames * 4))))) {
-					slices.length = 0; const per = Math.floor(h / frames); const rem = h - per * frames; let y0 = 0; for (let i=0;i<frames;i++){ const extra = i < rem ? 1 : 0; const sh = per + extra; slices.push({ sy: y0, sh }); y0 += sh; }
+				if (frames === 2) {
+					const margin = Math.round(h * 0.12);
+					const s = findSeamBetween(margin, h - margin);
+					slices.push({ sy: 0, sh: Math.max(1, s) });
+					slices.push({ sy: s + 1, sh: Math.max(1, h - s - 1) });
+				} else {
+					const margin = Math.round(h * 0.08);
+					const mid = findSeamBetween(margin, h - margin);
+					const top = findSeamBetween(margin, mid - Math.max(1, Math.floor(margin / 2)));
+					const bot = findSeamBetween(mid + Math.max(1, Math.floor(margin / 2)), h - margin);
+					slices.push({ sy: 0, sh: Math.max(1, top) });
+					slices.push({ sy: top + 1, sh: Math.max(1, mid - (top + 1)) });
+					slices.push({ sy: mid + 1, sh: Math.max(1, bot - (mid + 1)) });
+					slices.push({ sy: bot + 1, sh: Math.max(1, h - (bot + 1)) });
 				}
+				const minSh = Math.max(1, Math.floor(h / (frames * 4)));
+				if (slices.length !== frames || slices.some(s => s.sh < minSh)) { slices.length = 0; const per = Math.floor(h / frames); const rem = h - per * frames; let y0 = 0; for (let i = 0; i < frames; i++) { const extra = i < rem ? 1 : 0; const sh = per + extra; slices.push({ sy: y0, sh }); y0 += sh; } }
 				return slices;
 			} catch { return [{ sy: 0, sh: img?.height || TILE_SIZE }]; }
 		}

--- a/EDITMAPv6.html
+++ b/EDITMAPv6.html
@@ -2112,58 +2112,22 @@ class MapViewerApp {
 	}
 
 			getIconFrameRect(img) {
+			// Dùng cho NPC: chỉ hỗ trợ sprite-sheet dọc với 2 hoặc 4 frame chuẩn.
 			const w = img?.width || TILE_SIZE;
 			const h = img?.height || TILE_SIZE;
-			const clamp = (v, min, max) => Math.max(min, Math.min(max, v));
-			const nearInt = (x, eps) => Math.abs(x - Math.round(x)) <= eps;
-			let orientation = 'none';
 			let frames = 1;
-			// Ưu tiên phát hiện sprite-sheet theo tỉ lệ gần số nguyên 2..8 và mỗi frame gần-vuông
-			const tryVertical = () => {
+			if (w > 0 && h > 0) {
 				const ratio = h / w;
 				const n = Math.round(ratio);
-				if (n >= 2 && n <= 8 && nearInt(ratio, 0.08)) {
-					const seg = h / n;
-					if (Math.abs(seg / w - 1) <= 0.15) return n;
+				if ((n === 2 || n === 4) && Math.abs(ratio - n) < 0.005 && (h % n === 0)) {
+					frames = n;
 				}
-				return 1;
-			};
-			const tryHorizontal = () => {
-				const ratio = w / h;
-				const n = Math.round(ratio);
-				if (n >= 2 && n <= 8 && nearInt(ratio, 0.08)) {
-					const seg = w / n;
-					if (Math.abs(seg / h - 1) <= 0.15) return n;
-				}
-				return 1;
-			};
-			const fv = tryVertical();
-			const fh = tryHorizontal();
-			if (fv > 1 || fh > 1) {
-				if (fv > 1 && fh > 1) {
-					// Chọn phương án cho frame gần vuông hơn
-					const errV = Math.abs((h / fv) / w - 1);
-					const errH = Math.abs((w / fh) / h - 1);
-					if (errV <= errH) { orientation = 'vertical'; frames = fv; } else { orientation = 'horizontal'; frames = fh; }
-				} else if (fv > 1) { orientation = 'vertical'; frames = fv; }
-				else { orientation = 'horizontal'; frames = fh; }
 			}
 			let sx = 0, sy = 0, sw = w, sh = h;
 			if (frames > 1) {
 				const idx = Math.floor(Date.now() / this.animationTickMs) % frames;
-				if (orientation === 'vertical') {
-					const seg = h / frames;
-					const start = Math.round(idx * seg);
-					const end = Math.round((idx + 1) * seg);
-					sy = clamp(start, 0, h - 1);
-					sh = clamp(end - start, 1, h - sy);
-				} else if (orientation === 'horizontal') {
-					const seg = w / frames;
-					const start = Math.round(idx * seg);
-					const end = Math.round((idx + 1) * seg);
-					sx = clamp(start, 0, w - 1);
-					sw = clamp(end - start, 1, w - sx);
-				}
+				sh = h / frames;
+				sy = idx * sh;
 			}
 			return { sx, sy, sw, sh };
 		}

--- a/EDITMAPv6.html
+++ b/EDITMAPv6.html
@@ -2126,6 +2126,20 @@ class MapViewerApp {
 						const near = (x, y, tol) => Math.abs(x - y) <= tol;
 						if (near(ratio, 4, 0.25)) frames = 4;
 						else if (near(ratio, 2, 0.25)) frames = 2;
+						// Ambiguous band (~3.2-3.7 like 22x72, 26x86): probe alpha at midline to detect a clear 2-frame seam
+						else if (ratio > 3.0 && ratio < 3.8) {
+							try {
+								const c = document.createElement('canvas'); c.width = w; c.height = h; const ctx = c.getContext('2d'); ctx.imageSmoothingEnabled = false; ctx.drawImage(img, 0, 0);
+								const data = ctx.getImageData(0, 0, w, h).data;
+								const rowAlpha = (y) => { let s = 0; let o = y * w * 4 + 3; for (let x = 0; x < w; x++) { s += data[o]; o += 4; } return s / (255 * w); };
+								const mid = Math.floor(h / 2);
+								let center = 0; let cnt = 0; const band = Math.max(1, Math.round(h * 0.06));
+								for (let y = Math.max(1, mid - band); y <= Math.min(h - 2, mid + band); y++) { center += rowAlpha(y); cnt++; }
+								center = cnt > 0 ? center / cnt : 1;
+								// if center is much more transparent than neighbors, assume 2-frame
+								if (center <= 0.12) frames = 2; else frames = 4; // default to 4 when in doubt
+							} catch { frames = 4; }
+						}
 					}
 				}
 				const slices = [];

--- a/EDITMAPv6.html
+++ b/EDITMAPv6.html
@@ -1582,10 +1582,9 @@ class MapViewerApp {
 			drawEffect(effect) {
 			const icon = this.effectIcons.get(effect.templateId);
 			if (icon && icon.complete) {
-				const r = this.getIconFrameRect(icon);
-				const drawX = effect.x + (TILE_SIZE - r.sw) / 2;
-				const drawY = effect.y + (TILE_SIZE - r.sh) / 2;
-				this.ctx.drawImage(icon, r.sx, r.sy, r.sw, r.sh, drawX, drawY, r.sw, r.sh);
+				const drawX = effect.x + (TILE_SIZE - icon.width) / 2;
+				const drawY = effect.y + (TILE_SIZE - icon.height) / 2;
+				this.ctx.drawImage(icon, drawX, drawY, icon.width, icon.height);
 			} else {
 				this.ctx.fillStyle = 'rgba(255, 255, 0, 0.5)';
 				this.ctx.strokeStyle = '#cccc00';
@@ -1594,11 +1593,10 @@ class MapViewerApp {
 				this.ctx.strokeRect(effect.x, effect.y, TILE_SIZE, TILE_SIZE);
 			}
 			if (this.isIconEditingMode && this.selectedEffectObject === effect) {
-				const rSel = icon && icon.complete ? this.getIconFrameRect(icon) : { sx:0, sy:0, sw:TILE_SIZE, sh:TILE_SIZE };
-				const w = rSel.sw;
-				const h = rSel.sh;
-				const x = (icon && icon.complete) ? (effect.x + (TILE_SIZE - rSel.sw) / 2) : effect.x;
-				const y = (icon && icon.complete) ? (effect.y + (TILE_SIZE - rSel.sh) / 2) : effect.y;
+				const w = (icon && icon.complete) ? icon.width : TILE_SIZE;
+				const h = (icon && icon.complete) ? icon.height : TILE_SIZE;
+				const x = (icon && icon.complete) ? (effect.x + (TILE_SIZE - icon.width) / 2) : effect.x;
+				const y = (icon && icon.complete) ? (effect.y + (TILE_SIZE - icon.height) / 2) : effect.y;
 				this.highlightSelection(x, y, w, h);
 			}
 		}

--- a/EDITMAPv6.html
+++ b/EDITMAPv6.html
@@ -2117,7 +2117,8 @@ class MapViewerApp {
 				const w = img?.width || TILE_SIZE;
 				const h = img?.height || TILE_SIZE;
 				const ratio = h / Math.max(1, w);
-				let frames = (ratio >= 3.1) ? 4 : 1;
+				const near = (x, y, tol) => Math.abs(x - y) <= tol;
+				let frames = near(ratio, 4, 0.35) ? 4 : 1;
 				// không return sớm; sẽ thử dò seam giữa ảnh để xác nhận 2-frame, nếu không được thì giữ 1-frame
 				const c = document.createElement('canvas'); c.width = w; c.height = h; const ctx = c.getContext('2d'); ctx.imageSmoothingEnabled = false; ctx.drawImage(img, 0, 0);
 				const data = ctx.getImageData(0, 0, w, h).data;
@@ -2153,9 +2154,10 @@ class MapViewerApp {
 					// Thử phát hiện 2-frame bằng seam ở giữa; nếu seam yếu, coi như 1-frame
 					const margin = Math.round(h * 0.12);
 					const s = findSeamBetween(margin, h - margin);
-					const midBand = Math.max(1, Math.round(h * 0.05));
+					const midBand = Math.max(1, Math.round(h * 0.06));
 					let seamStrength = 1e9; for (let y = Math.max(1, s - midBand); y <= Math.min(h - 2, s + midBand); y++) seamStrength = Math.min(seamStrength, smoothed[y]);
-					if (seamStrength <= 0.08) {
+					const balance = Math.abs((s / h) - 0.5);
+					if (seamStrength <= 0.12 || balance <= 0.08) {
 						slices.push({ sy: 0, sh: Math.max(1, s) });
 						slices.push({ sy: s + 1, sh: Math.max(1, h - s - 1) });
 					} else {


### PR DESCRIPTION
Implemented sprite-sheet animation for NPC and effect icons to correctly render animated frames.

Previously, the application displayed entire sprite-sheet images as static icons, leading to multiple NPCs or effects appearing from a single image file (e.g., 2 NPCs from a 2-frame sprite, 4 from a 4-frame sprite). This change ensures that only the current frame of an animated icon is rendered, mimicking client-side behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-bb74d68e-2dc8-4bc8-a6c7-8f0a19f76604">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bb74d68e-2dc8-4bc8-a6c7-8f0a19f76604">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

